### PR TITLE
Add support for /payout endpoint

### DIFF
--- a/src/__tests__/payout.spec.ts
+++ b/src/__tests__/payout.spec.ts
@@ -4,7 +4,7 @@ import Payout from "../service/payout";
 import {
     ModifyRequest,
     StoreDetailAndSubmitRequest,
-    StoreDetailRequest, SubmitRequest
+    StoreDetailRequest, SubmitRequest, PayoutRequest
 } from "../typings/payout";
 import { FRAUD_MANUAL_REVIEW, FRAUD_RESULT_TYPE } from "../typings/constants/apiConstants";
 import Client from "../client";
@@ -65,6 +65,17 @@ const mockStoreDetailAndSubmitRequest = (merchantAccount: string): StoreDetailAn
     ...(mockStoreDetailRequest(merchantAccount)),
 });
 
+const mockPayoutRequest = (merchantAccount: string): PayoutRequest => ({
+  ...amountAndReference,
+  ...defaultData,
+  card: {
+    expiryMonth: "10",
+    expiryYear: "2020",
+    holderName: "John Smith",
+    number: "4111111111111111",
+  },
+  merchantAccount,
+});
 
 let client: Client;
 let payout: Payout;
@@ -141,5 +152,18 @@ describe("PayoutTest", function (): void {
 
         expect(result.response).toEqual("[payout-confirm-received]");
         expect(result.pspReference).toEqual("8815131762537886");
+    });
+
+    it("should succeed on payout", async function (): Promise<void> {
+      scope.post("/payout").reply(200, {
+          pspReference: "8815131762537886",
+          resultCode: "Received",
+      });
+
+      const request = mockPayoutRequest("MOCKED_MERCHANT_ACC");
+      const result = await payout.payout(request);
+
+      expect(result.resultCode).toEqual("Received");
+      expect(result.pspReference).toEqual("8815131762537886");
     });
 });

--- a/src/service/payout.ts
+++ b/src/service/payout.ts
@@ -24,12 +24,13 @@ import DeclineThirdParty from "./resource/payout/declineThirdParty";
 import StoreDetail from "./resource/payout/storeDetail";
 import SubmitThirdParty from "./resource/payout/submitThirdParty";
 import ConfirmThirdParty from "./resource/payout/confirmThirdParty";
+import PayoutResource from "./resource/payout/payout";
 import StoreDetailAndSubmitThirdParty from "./resource/payout/storeDetailAndSubmitThirdParty";
 import {
     ModifyRequest,
     ModifyResponse,
     StoreDetailAndSubmitRequest,
-    StoreDetailAndSubmitResponse, StoreDetailRequest, StoreDetailResponse, SubmitRequest, SubmitResponse
+    StoreDetailAndSubmitResponse, StoreDetailRequest, StoreDetailResponse, SubmitRequest, SubmitResponse, PayoutRequest, PayoutResponse
 } from "../typings/payout";
 import getJsonResponse from "../helpers/getJsonResponse";
 
@@ -39,6 +40,7 @@ class Payout extends Service {
     private readonly _declineThirdParty: DeclineThirdParty;
     private readonly _storeDetail: StoreDetail;
     private readonly _submitThirdParty: SubmitThirdParty;
+		private readonly _payout: PayoutResource;
 
     public constructor(client: Client) {
         super(client);
@@ -48,6 +50,7 @@ class Payout extends Service {
         this._declineThirdParty = new DeclineThirdParty(this);
         this._storeDetail = new StoreDetail(this);
         this._submitThirdParty = new SubmitThirdParty(this);
+				this._payout = new PayoutResource(this);
     }
 
     public storeDetailAndSubmitThirdParty(request: StoreDetailAndSubmitRequest): Promise<StoreDetailAndSubmitResponse> {
@@ -82,6 +85,13 @@ class Payout extends Service {
         return getJsonResponse<SubmitRequest, SubmitResponse>(
             this._submitThirdParty,
             request
+        );
+    }
+
+    public payout(request: PayoutRequest): Promise<PayoutResponse> {
+        return getJsonResponse<PayoutRequest, PayoutResponse>(
+          this._payout,
+          request
         );
     }
 }

--- a/src/service/payout.ts
+++ b/src/service/payout.ts
@@ -40,7 +40,7 @@ class Payout extends Service {
     private readonly _declineThirdParty: DeclineThirdParty;
     private readonly _storeDetail: StoreDetail;
     private readonly _submitThirdParty: SubmitThirdParty;
-		private readonly _payout: PayoutResource;
+    private readonly _payout: PayoutResource;
 
     public constructor(client: Client) {
         super(client);
@@ -50,7 +50,7 @@ class Payout extends Service {
         this._declineThirdParty = new DeclineThirdParty(this);
         this._storeDetail = new StoreDetail(this);
         this._submitThirdParty = new SubmitThirdParty(this);
-				this._payout = new PayoutResource(this);
+        this._payout = new PayoutResource(this);
     }
 
     public storeDetailAndSubmitThirdParty(request: StoreDetailAndSubmitRequest): Promise<StoreDetailAndSubmitResponse> {

--- a/src/service/resource/payout/payout.ts
+++ b/src/service/resource/payout/payout.ts
@@ -1,0 +1,34 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen NodeJS API Library
+ *
+ * Copyright (c) 2019 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+import Resource from "../../resource";
+import Service from "../../../service";
+import Client from "../../../client";
+
+class Payout extends Resource {
+    public constructor(service: Service) {
+        super(
+            service,
+            `${service.client.config.endpoint}/pal/servlet/Payout/${Client.API_VERSION}/payout`
+        );
+    }
+}
+
+export default Payout;


### PR DESCRIPTION
It was impossible to send PayoutRequest to /payout

[API Reference](https://docs.adyen.com/api-explorer/#/Payout/v30/payout)