### PR TITLE
Add requestOptions to paymentDetails

### DIFF
--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -71,10 +71,11 @@ class Checkout extends ApiKeyAuthenticatedService {
         );
     }
 
-    public paymentsDetails(paymentsDetailsRequest: ICheckout.DetailsRequest): Promise<ICheckout.PaymentResponse> {
+    public paymentsDetails(paymentsDetailsRequest: ICheckout.DetailsRequest, requestOptions?: IRequest.Options): Promise<ICheckout.PaymentResponse> {
         return getJsonResponse<ICheckout.DetailsRequest, ICheckout.PaymentResponse>(
             this._paymentsDetails,
             paymentsDetailsRequest,
+            requestOptions
         );
     }
 


### PR DESCRIPTION
Added the possibility to pass request options to paymentDetails. My use case was enabling API idempotency on paymentDetails requests.
