### PR TITLE
Updated link under Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install --save @adyen/api-library
 
 ## Documentation
 * https://docs.adyen.com/developers/development-resources/libraries
-* https://docs.adyen.com/developers/checkout/api-integration
+* https://docs.adyen.com/developers/checkout
 
 ## HTTP Client Configuration
 


### PR DESCRIPTION
**What problem you’re solving**
Under **Documentation**, we only link to the API-only integration. But the library can also be used  to integrate with the Drop-in and Components integrations.

**Your approach to fixing the problem**
Updated the URL, so it points to the main [Checkout page](https://docs.adyen.com/checkout).

**Any tests you wrote**
N/A