### PR TITLE
Pw 4625/nexocrypto special characters

### DIFF
--- a/src/__mocks__/base.ts
+++ b/src/__mocks__/base.ts
@@ -21,12 +21,17 @@ import Client from "../client";
 import Config from "../config";
 import {
     AmountsReq,
+    DocumentQualifierType,
     MessageCategoryType,
     MessageClassType,
     MessageHeader,
     MessageType,
+    OutputFormatType,
+    OutputText,
     PaymentRequest,
     PaymentTransaction,
+    PrintRequest,
+    ResponseModeType,
     ReversalReasonType,
     ReversalRequest,
     SaleData,
@@ -34,6 +39,8 @@ import {
     TerminalApiRequest,
     TransactionIdentification
 } from "../typings/terminal/models";
+import CharacterStyleEnum = OutputText.CharacterStyleEnum;
+import AlignmentEnum = OutputText.AlignmentEnum;
 
 export const createClient = (apiKey = process.env.ADYEN_API_KEY): Client => {
     const config: Config = new Config();
@@ -101,6 +108,34 @@ const paymentRequest: PaymentRequest = {
     saleData,
 };
 
+const printRequest: PrintRequest = {
+    printOutput: {
+        documentQualifier:DocumentQualifierType.CashierReceipt,
+        responseMode: ResponseModeType.PrintEnd,
+        outputContent: {
+            outputFormat: OutputFormatType.Text,
+            outputText:[
+                {
+                    characterStyle: CharacterStyleEnum.Bold,
+                    alignment: AlignmentEnum.Centred,
+                    endOfLineFlag:true,
+                    text:"This is a title"
+                },
+                {
+                    endOfLineFlag:false,
+                    alignment: AlignmentEnum.Left,
+                    text:"This is the key"
+                },
+                {
+                    endOfLineFlag:true,
+                    alignment: AlignmentEnum.Right,
+                    text:"value - üäöÖÜÄß"
+                },
+            ],
+        }
+    }
+};
+
 const getReversalRequest = (poiTransaction: TransactionIdentification): ReversalRequest => ({
     originalPOITransaction: {
         pOITransactionID: {
@@ -126,5 +161,11 @@ export const createTerminalAPIPaymentRequest = (): TerminalApiRequest => {
 export const createTerminalAPIRefundRequest = (transactionIdentification: TransactionIdentification): TerminalApiRequest => {
     const messageHeader = getMessageHeader({ messageCategory: MessageCategoryType.Reversal });
     const saleToPOIRequest = getSaleToPOIRequest(messageHeader, { reversalRequest: getReversalRequest(transactionIdentification) });
+    return { saleToPOIRequest };
+};
+
+export const createTerminalAPIReceiptRequest = (): TerminalApiRequest => {
+    const messageHeader = getMessageHeader({ messageCategory: MessageCategoryType.Print});
+    const saleToPOIRequest = getSaleToPOIRequest(messageHeader, { printRequest });
     return { saleToPOIRequest };
 };

--- a/src/security/nexoCrypto.ts
+++ b/src/security/nexoCrypto.ts
@@ -42,7 +42,7 @@ class NexoCrypto {
         securityKey: SecurityKey,
     ): SaleToPOISecuredMessage {
         const derivedKey: NexoDerivedKey = NexoDerivedKeyGenerator.deriveKeyMaterial(securityKey.passphrase);
-        const saleToPoiMessageByteArray = Buffer.from(saleToPoiMessageJson, "ascii");
+        const saleToPoiMessageByteArray = Buffer.from(saleToPoiMessageJson, "utf-8");
         const ivNonce = NexoCrypto.generateRandomIvNonce();
         const encryptedSaleToPoiMessage = NexoCrypto.crypt(saleToPoiMessageByteArray, derivedKey, ivNonce, Modes.ENCRYPT);
         const encryptedSaleToPoiMessageHmac = NexoCrypto.hmac(saleToPoiMessageByteArray, derivedKey);
@@ -74,7 +74,7 @@ class NexoCrypto {
         const receivedHmac = Buffer.from(saleToPoiSecureMessage.securityTrailer.hmac, "base64");
         this.validateHmac(receivedHmac, decryptedSaleToPoiMessageByteArray, derivedKey);
 
-        return decryptedSaleToPoiMessageByteArray.toString("ascii");
+        return decryptedSaleToPoiMessageByteArray.toString("utf-8");
     }
 
     private static validateSecurityKey(securityKey: SecurityKey): void {

--- a/src/services/terminalLocalAPI.ts
+++ b/src/services/terminalLocalAPI.ts
@@ -47,7 +47,6 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
         securityKey: SecurityKey,
     ): Promise<TerminalApiResponse> {
         const formattedRequest = ObjectSerializer.serialize(terminalApiRequest, "TerminalApiRequest");
-
         if (formattedRequest.SaleToPOIRequest?.PaymentRequest?.SaleData?.SaleToAcquirerData) {
             const dataString = JSON.stringify(formattedRequest.SaleToPOIRequest.PaymentRequest.SaleData.SaleToAcquirerData);
             formattedRequest.SaleToPOIRequest.PaymentRequest.SaleData.SaleToAcquirerData = Buffer.from(dataString).toString("base64");


### PR DESCRIPTION
**Description**
When attempting to send a "Print" request to POS Verifone terminal, where the receipt contains German letters (for example: üäöÖÜÄß), the response has an exception: 400. Bad Request.
'ascii' does not include the German characters among others as well, so I changed the encoding to 'utf-8' which successfully prints the characters on the terminal receipt

**Fixed issue**:  Fixed issue raised in PR: https://github.com/Adyen/adyen-node-api-library/pull/657
