### PR TITLE
Fix/local terminal api bug

### DIFF
--- a/src/__tests__/binLookup.spec.ts
+++ b/src/__tests__/binLookup.spec.ts
@@ -127,18 +127,3 @@ describe("Bin Lookup", function (): void {
         expect(response).toEqual(expected);
     });
 });
-
-
-Vince Vissers
-Email
-vince.vissers@adyen.com
-Phone
-(+31) 621161626
-Company
-Adyen
-Street address
-Simon Carmiggeltstraat 6-50, 1011DJ
-City
-Amsterdam
-Country
-N-H, Netherlands

--- a/src/__tests__/binLookup.spec.ts
+++ b/src/__tests__/binLookup.spec.ts
@@ -87,6 +87,15 @@ describe("Bin Lookup", function (): void {
     test.each([false, true])("should succeed on get cost estimate. isMock: %p", async function (isMock): Promise<void> {
         !isMock && nock.restore();
         const expected = {
+            cardBin:  {
+             bin: "",
+             fundsAvailability: "I",
+             issuingBank: "ADYEN TEST BANK",
+             issuingCountry: "NL",
+             paymentMethod: "visa",
+             payoutEligible: "Y",
+             summary: "",
+           },
             costEstimateAmount: {
                 currency: "EUR",
                 value: 10
@@ -118,3 +127,18 @@ describe("Bin Lookup", function (): void {
         expect(response).toEqual(expected);
     });
 });
+
+
+Vince Vissers
+Email
+vince.vissers@adyen.com
+Phone
+(+31) 621161626
+Company
+Adyen
+Street address
+Simon Carmiggeltstraat 6-50, 1011DJ
+City
+Amsterdam
+Country
+N-H, Netherlands

--- a/src/__tests__/checkout.spec.ts
+++ b/src/__tests__/checkout.spec.ts
@@ -184,7 +184,7 @@ describe("Checkout", (): void => {
 
     test.each([false, true])("should have valid payment methods, isMock: %p", async (isMock): Promise<void> => {
         !isMock && nock.restore();
-        const paymentMethodsRequest: PaymentMethodsRequest = {merchantAccount: "MagentoMerchantTest"};
+        const paymentMethodsRequest: PaymentMethodsRequest = {merchantAccount};
 
         scope.post("/paymentMethods")
             .reply(200, paymentMethodsSuccess);

--- a/src/services/terminalLocalAPI.ts
+++ b/src/services/terminalLocalAPI.ts
@@ -60,7 +60,7 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
         );
 
         const securedPaymentRequest: TerminalApiSecuredRequest = ObjectSerializer.serialize({
-            saleToPOIRequest: saleToPoiSecuredMessage,
+            SaleToPOIRequest: saleToPoiSecuredMessage,
         }, "TerminalApiSecuredRequest");
 
         const jsonResponse = await getJsonResponse<TerminalApiSecuredRequest, TerminalApiResponse>(


### PR DESCRIPTION
**Description**
This fix solves a bug caused by a uppercase mismatch in type names when serializing SaleToPOIRequest during local terminal API requests.

**Tested scenarios**
Reproduced #762 and solved it using a physical device

**Fixed issue**:   #762 
