### PR TITLE
#838 - Fixes for to return `TerminalApiRequest`.

### DIFF
--- a/src/__mocks__/terminalApi/sync.ts
+++ b/src/__mocks__/terminalApi/sync.ts
@@ -365,3 +365,12 @@ export const syncRefund = {
         }
     }
 };
+
+export const syncResEventNotification = {
+    EventNotification: {
+        RejectedMessage: "abc_xyz_123=",
+        EventToNotify: "Reject",
+        TimeStamp: "2019-04-29T00:00:00.000Z",
+        EventDetails: "message=Failed+to+send+message+to+POI.+There+may+be+a+network+issue+or+it+may+not+have+the+websocket+connected.",
+    }
+};

--- a/src/services/terminalCloudAPI.ts
+++ b/src/services/terminalCloudAPI.ts
@@ -64,12 +64,15 @@ class TerminalCloudAPI extends ApiKeyAuthenticatedService {
         return getJsonResponse<TerminalApiRequest>(this.terminalApiAsync, request);
     }
 
-    public async sync(terminalApiRequest: TerminalApiRequest): Promise<TerminalApiResponse> {
+    public async sync(terminalApiRequest: TerminalApiRequest): Promise<TerminalApiRequest | TerminalApiResponse> {
         const request = TerminalCloudAPI.setApplicationInfo(terminalApiRequest);
-        const response = await getJsonResponse<TerminalApiRequest, TerminalApiResponse>(
+        const response = await getJsonResponse<TerminalApiRequest, TerminalApiRequest | TerminalApiResponse>(
             this.terminalApiSync,
             request,
         );
+
+        if ((response as TerminalApiRequest).SaleToPOIRequest)
+            return ObjectSerializer.deserialize(response, "TerminalApiRequest");
 
         return ObjectSerializer.deserialize(response, "TerminalApiResponse");
     }


### PR DESCRIPTION
**Description**
Added fixes for terminal sync to return `TerminalApiRequest` as well.

**Tested scenarios**
- Added test case when `SaleToPOIRequest` is returned as a response.

**Fixed issue**: #838.