### PR TITLE
Terminal API barcodetype enum value 'Qrcode' should not be all caps

### DIFF
--- a/src/typings/terminal/outputBarcode.ts
+++ b/src/typings/terminal/outputBarcode.ts
@@ -61,7 +61,7 @@ export namespace OutputBarcode {
         Ean13 = <any> 'EAN13',
         Ean8 = <any> 'EAN8',
         Pdf417 = <any> 'PDF417',
-        Qrcode = <any> 'QRCODE',
+        Qrcode = <any> 'QRCode',
         Upca = <any> 'UPCA'
     }
 }


### PR DESCRIPTION
Got a remark in library QA MM that the value of qrcode was wrong. Set it according to the docs.

https://docs.adyen.com/point-of-sale/terminal-api-reference#comadyennexobarcodetype
