### PR TITLE
allow splits terminal for marketplace

### DIFF
--- a/src/typings/terminal/models.ts
+++ b/src/typings/terminal/models.ts
@@ -854,6 +854,9 @@ export class ObjectSerializer {
         } else if (type === "Date") {
             return data.toISOString();
         } else if (type === "SaleToAcquirerData") {
+            if (typeof data === 'string') {
+                return data; // splits payment for terminal
+            }
             const dataString = JSON.stringify(data);
             return Buffer.from(dataString).toString("base64");
         } else {

--- a/src/typings/terminal/saleData.ts
+++ b/src/typings/terminal/saleData.ts
@@ -43,7 +43,7 @@ export class SaleData {
     'OperatorLanguage'?: string;
     'SaleReferenceID'?: string;
     'SaleTerminalData'?: SaleTerminalData;
-    'SaleToAcquirerData'?: SaleToAcquirerData;
+    'SaleToAcquirerData'?: SaleToAcquirerData | string;
     'SaleToIssuerData'?: SaleToIssuerData;
     'SaleToPOIData'?: string;
     'SaleTransactionID': TransactionIdentification;


### PR DESCRIPTION
**Description**
In this PR, we let the user the possibility to send a splits terminal payment query.
`SaleToAcquirerData` needs to receive a string :  `split.api=1&...`

**Fixed**: 
We check in the model if the `SaleToAcquirerData` is a string. Then we directly return the string.
