### PR TITLE
[PW-7079] fix abort request localterminal API

### DIFF
--- a/src/services/terminalLocalAPI.ts
+++ b/src/services/terminalLocalAPI.ts
@@ -31,9 +31,6 @@ import {
     TerminalApiSecuredRequest,
     TerminalApiSecuredResponse
 } from "../typings/terminal/models";
-import NexoCryptoException from "./exception/nexoCryptoException";
-import HttpClientException from "../httpClient/httpClientException";
-import apiException from "./exception/apiException";
 
 class TerminalLocalAPI extends ApiKeyAuthenticatedService {
     private readonly localRequest: LocalRequest;
@@ -60,13 +57,15 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
             SaleToPOIRequest: saleToPoiSecuredMessage,
         }, "TerminalApiSecuredRequest");
 
-        // Catch Exceptions and an empty jsonResponse (i.e. Abort Request)
-        try {
-            const jsonResponse = await getJsonResponse<TerminalApiSecuredRequest, TerminalApiResponse>(
-                this.localRequest,
-                securedPaymentRequest
-            );
+        const jsonResponse = await getJsonResponse<TerminalApiSecuredRequest, TerminalApiResponse>(
+            this.localRequest,
+            securedPaymentRequest
+        );
 
+        // Catch an empty jsonResponse (i.e. Abort Request)
+        if(!jsonResponse) {
+            return new TerminalApiResponse();
+        } else {
             const terminalApiSecuredResponse: TerminalApiSecuredResponse =
                 ObjectSerializer.deserialize(jsonResponse, "TerminalApiSecuredResponse");
 
@@ -75,13 +74,6 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
                 securityKey,
             );
             return ObjectSerializer.deserialize(JSON.parse(response), "TerminalApiResponse");
-
-        } catch (e) {
-            if(e instanceof NexoCryptoException || e instanceof HttpClientException || e instanceof apiException) {
-                throw e;
-            } else {
-                return new TerminalApiResponse();
-            }
         }
     }
 }

--- a/src/services/terminalLocalAPI.ts
+++ b/src/services/terminalLocalAPI.ts
@@ -31,6 +31,7 @@ import {
     TerminalApiSecuredRequest,
     TerminalApiSecuredResponse
 } from "../typings/terminal/models";
+import NexoCryptoException from "./exception/nexoCryptoException";
 
 class TerminalLocalAPI extends ApiKeyAuthenticatedService {
     private readonly localRequest: LocalRequest;
@@ -62,9 +63,10 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
             securedPaymentRequest
         );
 
-        console.log("jsonresponse" + jsonResponse.toString());
-        // Catch an empty jsonResponse (i.e. Abort Request)
+        console.log("jsonresponse type" +  typeof jsonResponse);
+        console.log(jsonResponse);
 
+        // Catch an empty jsonResponse (i.e. Abort Request)
         try {
             const terminalApiSecuredResponse: TerminalApiSecuredResponse =
                 ObjectSerializer.deserialize(jsonResponse, "TerminalApiSecuredResponse");
@@ -76,8 +78,12 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
             return ObjectSerializer.deserialize(JSON.parse(response), "TerminalApiResponse");
 
         } catch (e) {
-            const requestType = terminalApiRequest.SaleToPOIRequest.MessageHeader.MessageCategory;
-            throw new Error(`Request of type ${requestType} has no response!`);
+            if(e instanceof NexoCryptoException){
+                throw e;
+            } else {
+                const requestType = terminalApiRequest.SaleToPOIRequest.MessageHeader.MessageCategory;
+                throw new Error(`Request of type ${requestType} has no response!`);
+            }
         }
     }
 }

--- a/src/services/terminalLocalAPI.ts
+++ b/src/services/terminalLocalAPI.ts
@@ -45,7 +45,7 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
     public async request(
         terminalApiRequest: TerminalApiRequest,
         securityKey: SecurityKey,
-    ): Promise<TerminalApiResponse> {
+    ): Promise<any> {
         const formattedRequest = ObjectSerializer.serialize(terminalApiRequest, "TerminalApiRequest");
         const saleToPoiSecuredMessage: SaleToPOISecuredMessage = NexoCrypto.encrypt(
             terminalApiRequest.SaleToPOIRequest.MessageHeader,
@@ -62,15 +62,20 @@ class TerminalLocalAPI extends ApiKeyAuthenticatedService {
             securedPaymentRequest
         );
 
-        const terminalApiSecuredResponse: TerminalApiSecuredResponse =
-            ObjectSerializer.deserialize(jsonResponse, "TerminalApiSecuredResponse");
+        // Catch an empty jsonResponse (i.e. Abort Request)
+        if(jsonResponse == ""){
+            return Promise.resolve();
+        } else {
+            const terminalApiSecuredResponse: TerminalApiSecuredResponse =
+                ObjectSerializer.deserialize(jsonResponse, "TerminalApiSecuredResponse");
 
-        const response = this.nexoCrypto.decrypt(
-            terminalApiSecuredResponse.SaleToPOIResponse,
-            securityKey,
-        );
+            const response = this.nexoCrypto.decrypt(
+                terminalApiSecuredResponse.SaleToPOIResponse,
+                securityKey,
+                );
 
-        return ObjectSerializer.deserialize(JSON.parse(response), "TerminalApiResponse");
+            return ObjectSerializer.deserialize(JSON.parse(response), "TerminalApiResponse");
+        }
     }
 }
 


### PR DESCRIPTION
**Description**
Catches empty string returned from jsonResponse to recognise abortRequest.

**Tested scenarios**
IT/UT

**Fixed issue**:  #905 
