### PR TITLE
Changing name of Value to BarcodeValue in OutputBarcode corresponding to docs (and API)

### DIFF
--- a/src/typings/terminal/outputBarcode.ts
+++ b/src/typings/terminal/outputBarcode.ts
@@ -33,7 +33,7 @@
 
 export class OutputBarcode {
     'BarcodeType'?: OutputBarcode.BarcodeTypeEnum;
-    'Value'?: string;
+    'BarcodeValue'?: string;
 
     static discriminator: string | undefined = undefined;
 
@@ -44,8 +44,8 @@ export class OutputBarcode {
             "type": "OutputBarcode.BarcodeTypeEnum"
         },
         {
-            "name": "Value",
-            "baseName": "Value",
+            "name": "BarcodeValue",
+            "baseName": "BarcodeValue",
             "type": "string"
         }    ];
 


### PR DESCRIPTION
**Description**
#1048 mentioned that populating the field for a print-request yield an error saying the ```Value``` is not a correct field. Indeed instead it should have been ```BarcodeValue```, so I changed it accordingly.

**Tested scenarios**
Tested it on a POS machine and indeed I got the same error. When adjusting the name field to the correct one I was able to successfully print a receipt. 

**Fixed issue**: #1048 
