### PR TITLE
PW-7502: Bind QueryString type to URLSearchParams

### DIFF
--- a/src/typings/requestOptions.ts
+++ b/src/typings/requestOptions.ts
@@ -25,7 +25,8 @@ import * as https from "https";
 import { URLSearchParams } from "url";
 
 export namespace IRequest {
-    type QueryString = URLSearchParams | string | NodeJS.Dict<string | string[]> | Iterable<[string, string]> | Array<[string, string]>;
+    type QueryString = ConstructorParameters<typeof URLSearchParams>[0];
+
     export type Options = https.RequestOptions & {
         idempotencyKey?: string;
         params?: QueryString;


### PR DESCRIPTION
**Description**

This change makes the `QueryString` type definition dynamic. It allows us to perform minor upgrades like #1044.

**Tests** 

* @types/node at 14.0.9  
* @types/node at 14.18.36
