### PR TITLE
ITT-377: Create Github Release automatically

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,8 @@
 changelog:
   exclude:
     authors:
-      - renovate
-      - dependabot
+      - app/renovate
+      - app/dependabot
   categories:
     - title: Breaking Changes 🛠
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,8 @@
 changelog:
   exclude:
     authors:
-      - app/renovate
-      - app/dependabot
+      - renovate[bot]
+      - dependabot[bot]
   categories:
     - title: Breaking Changes 🛠
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    authors:
+      - renovate
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Breaking change
+    - title: New Features 💎
+      labels:
+        - Feature
+    - title: Fixes ⛑️
+      labels:
+        - Fix
+    - title: Other Changes 🖇️
+      labels:
+        - "*"

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ITT-377
 
 jobs:
   gh_release:

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,30 @@
+name: Github Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - ITT-377
+
+jobs:
+  gh_release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Grab version
+        uses: actions/github-script@v6
+        id: release
+        with:
+          script: |
+            const release = require('./.github/scripts/release.js')
+            core.setOutput('version', release.packageVersion())
+      - name: Create new release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create v${{steps.release.outputs.version}} \
+            --title 'Adyen Node API Library v${{steps.release.outputs.version}}' \
+            --generate-notes --target main --draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Bump package.json
         run: npm --no-git-tag-version version ${{steps.release.outputs.nextVersion}}
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
@@ -43,3 +44,10 @@ jobs:
             ${{steps.release.outputs.changelog}}
           commit-message: "chore(release): bump to ${{steps.release.outputs.nextVersion}}"
           delete-branch: true
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc # v2.5.0
+        with:
+          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: merge


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Adds a new workflow that creates a **draft** Github Release when we merge changes (a release PR) into `main` branch. We can remove the draft flag after a few real releases. 

Another change is to enable auto-merge for the release PR to make sure we don't squash it anymore. 

**Tested scenarios**
<!-- Description of tested scenarios -->
* run the workflow with a development branch: https://github.com/Adyen/adyen-node-api-library/actions/workflows/gh-release.yml 
