### PR TITLE
Fix ForceEntryMode typings

### DIFF
--- a/src/typings/terminal/cardAcquisitionTransaction.ts
+++ b/src/typings/terminal/cardAcquisitionTransaction.ts
@@ -37,7 +37,7 @@ export class CardAcquisitionTransaction {
     'CashBackFlag'?: boolean;
     'CustomerLanguage'?: string;
     'ForceCustomerSelectionFlag'?: boolean;
-    'ForceEntryMode'?: Array<Array<CardAcquisitionTransaction.ForceEntryModeEnum>>;
+    'ForceEntryMode'?: Array<CardAcquisitionTransaction.ForceEntryModeEnum>;
     'LoyaltyHandling'?: CardAcquisitionTransaction.LoyaltyHandlingEnum;
     'PaymentType'?: CardAcquisitionTransaction.PaymentTypeEnum;
     'TotalAmount'?: number;
@@ -73,7 +73,7 @@ export class CardAcquisitionTransaction {
         {
             "name": "ForceEntryMode",
             "baseName": "ForceEntryMode",
-            "type": "Array<Array<CardAcquisitionTransaction.ForceEntryModeEnum>>"
+            "type": "Array<CardAcquisitionTransaction.ForceEntryModeEnum>"
         },
         {
             "name": "LoyaltyHandling",

--- a/src/typings/terminal/cardReaderInitRequest.ts
+++ b/src/typings/terminal/cardReaderInitRequest.ts
@@ -34,7 +34,7 @@ import { DisplayOutput } from './displayOutput';
 
 export class CardReaderInitRequest {
     'DisplayOutput'?: DisplayOutput;
-    'ForceEntryMode'?: Array<Array<CardReaderInitRequest.ForceEntryModeEnum>>;
+    'ForceEntryMode'?: Array<CardReaderInitRequest.ForceEntryModeEnum>;
     'LeaveCardFlag'?: boolean;
     'MaxWaitingTime'?: number;
     'WarmResetFlag'?: boolean;
@@ -50,7 +50,7 @@ export class CardReaderInitRequest {
         {
             "name": "ForceEntryMode",
             "baseName": "ForceEntryMode",
-            "type": "Array<Array<CardReaderInitRequest.ForceEntryModeEnum>>"
+            "type": "Array<CardReaderInitRequest.ForceEntryModeEnum>"
         },
         {
             "name": "LeaveCardFlag",

--- a/src/typings/terminal/transactionConditions.ts
+++ b/src/typings/terminal/transactionConditions.ts
@@ -37,7 +37,7 @@ export class TransactionConditions {
     'AllowedPaymentBrand'?: Array<string>;
     'CustomerLanguage'?: string;
     'DebitPreferredFlag'?: boolean;
-    'ForceEntryMode'?: Array<Array<TransactionConditions.ForceEntryModeEnum>>;
+    'ForceEntryMode'?: Array<TransactionConditions.ForceEntryModeEnum>;
     'ForceOnlineFlag'?: boolean;
     'LoyaltyHandling'?: TransactionConditions.LoyaltyHandlingEnum;
     'MerchantCategoryCode'?: string;
@@ -73,7 +73,7 @@ export class TransactionConditions {
         {
             "name": "ForceEntryMode",
             "baseName": "ForceEntryMode",
-            "type": "Array<Array<TransactionConditions.ForceEntryModeEnum>>"
+            "type": "Array<TransactionConditions.ForceEntryModeEnum>"
         },
         {
             "name": "ForceOnlineFlag",


### PR DESCRIPTION
**Description**
Change typings of ForceEntryMode to Array<ForceEntryModeEnum>`` instead of `Array<Array<ForceEntryModeEnum>>`.
The files say that they are generated but seems like that is just copied as nothing seems to generate them and other people have manually changed them before.

**Tested scenarios**
I have tested this on a local terminal both with and without any ForceEntryMode set. Both works as expected.

**Fixed issue**:  #1184
