### PR TITLE
Use `npm config` when setting auth token during publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -15,8 +15,8 @@ jobs:
           node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: |
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN }}
           npm install
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN }}" > .npmrc
           npm run build
           npm publish
         env:


### PR DESCRIPTION
For whatever reason, echoing the auth token to `.npmrc` doesn't get picked up during publishing, let's try this