### PR TITLE
Update npmpublish.yml again

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -12,13 +12,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
-          registry-url: https://registry.npmjs.org/
+          node-version: 18.x
+          registry-url: 'https://registry.npmjs.org'
       - run: |
-          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN }}
           npm install
           npm run build
-          npm publish
+      - run: npm publish
         env:
-          GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN }}


### PR DESCRIPTION
- Uses the same node-version as during the `coverall` workflow  
- Uses `NODE_AUTH_TOKEN` as described in the [documentation](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm)
