### PR TITLE
Revert removing `npm config set` when npm publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -15,8 +15,7 @@ jobs:
           node-version: 18.x
           registry-url: 'https://registry.npmjs.org'
       - run: |
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN }}
           npm install
           npm run build
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN }}


### PR DESCRIPTION
We followed the [documentation](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm) but got an `ENEEDAUTH` error.

With the `npm config set` approach we got a 404 instead, which suggests a wrong API key.   However, we know the API key was correct, so the other option was having conflicting ways to configure publishing (`NODE_AUTH_TOKEN` and `npm config set` were both present), or a string interpolation issue (there were no spaces inside the braces).

This commit implements only a single way to configure the auth token.