### PR TITLE
Add @deprecated tag: mark deprecated attributes of the models in the OpenAPI files

### DIFF
--- a/templates/typescript/api_summary.mustache
+++ b/templates/typescript/api_summary.mustache
@@ -17,7 +17,7 @@
 {{/returnType}}
 {{#isDeprecated}}
     *
-	* @deprecated since v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+	* @deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
 	* {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
 {{/isDeprecated}}
     */

--- a/templates/typescript/api_summary.mustache
+++ b/templates/typescript/api_summary.mustache
@@ -17,7 +17,7 @@
 {{/returnType}}
 {{#isDeprecated}}
     *
-	* @deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-	* {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
+	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+	* {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/vendorExtensions.x-deprecatedInVersion}}
 {{/isDeprecated}}
     */

--- a/templates/typescript/api_summary.mustache
+++ b/templates/typescript/api_summary.mustache
@@ -15,4 +15,9 @@
 {{#returnType}}
     * @return {@link {{.}} }
 {{/returnType}}
+{{#isDeprecated}}
+    *
+	* @deprecated since v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+	* {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
+{{/isDeprecated}}
     */

--- a/templates/typescript/api_summary.mustache
+++ b/templates/typescript/api_summary.mustache
@@ -17,7 +17,7 @@
 {{/returnType}}
 {{#isDeprecated}}
     *
-	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-	* {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/vendorExtensions.x-deprecatedInVersion}}
+	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}}
+	* {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
 {{/isDeprecated}}
     */

--- a/templates/typescript/model.mustache
+++ b/templates/typescript/model.mustache
@@ -18,16 +18,16 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     * {{{.}}}
     {{#deprecated}}
     *
-    * @deprecated since v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-    * {{#vendorExtensions.x-deprecatedMessage}}{{..}}{{/vendorExtensions.x-deprecatedMessage}}
+	* @deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
     {{/deprecated}}
     */
 {{/description}}
 {{^description}}
     {{#deprecated}}
     /**
-    * @deprecated since v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-    * {{#vendorExtensions.x-deprecatedMessage}}{{..}}{{/vendorExtensions.x-deprecatedMessage}}
+	* @deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
     */
     {{/deprecated}}
 {{/description}}

--- a/templates/typescript/model.mustache
+++ b/templates/typescript/model.mustache
@@ -16,7 +16,20 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#description}}
     /**
     * {{{.}}}
+    {{#deprecated}}
+    *
+    * @deprecated since v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+    * {{#vendorExtensions.x-deprecatedMessage}}{{..}}{{/vendorExtensions.x-deprecatedMessage}}
+    {{/deprecated}}
     */
+{{/description}}
+{{^description}}
+    {{#deprecated}}
+    /**
+    * @deprecated since v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+    * {{#vendorExtensions.x-deprecatedMessage}}{{..}}{{/vendorExtensions.x-deprecatedMessage}}
+    */
+    {{/deprecated}}
 {{/description}}
     '{{name}}'{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};
 {{/vars}}

--- a/templates/typescript/model.mustache
+++ b/templates/typescript/model.mustache
@@ -18,16 +18,16 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     * {{{.}}}
     {{#deprecated}}
     *
-	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/vendorExtensions.x-deprecatedInVersion}}
+	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}}
+	* {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
     {{/deprecated}}
     */
 {{/description}}
 {{^description}}
     {{#deprecated}}
     /**
-	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/vendorExtensions.x-deprecatedInVersion}}
+	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}}
+	* {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
     */
     {{/deprecated}}
 {{/description}}

--- a/templates/typescript/model.mustache
+++ b/templates/typescript/model.mustache
@@ -18,16 +18,16 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
     * {{{.}}}
     {{#deprecated}}
     *
-	* @deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
+	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/vendorExtensions.x-deprecatedInVersion}}
     {{/deprecated}}
     */
 {{/description}}
 {{^description}}
     {{#deprecated}}
     /**
-	* @deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
-    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}
+	* @deprecated {{#vendorExtensions.x-deprecatedInVersion}}since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}
+    * {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}{{/vendorExtensions.x-deprecatedInVersion}}
     */
     {{/deprecated}}
 {{/description}}


### PR DESCRIPTION
**Description**

The OpenAPI specs deprecate endpoints and models, but the code generation of the NodeJS library doesn't deprecate the corresponding code.

Proposed improvement 
Add the `@deprecated` tag to the corresponding code, include the extensions `x-deprecatedInVersion` and `x-deprecatedMessage` too.


