### PR TITLE
Upgrade @types/node: Update to 18.19.69 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "https-proxy-agent": "5.0.1"
   },
   "optionalDependencies": {
-    "@types/node": "14.18.63"
+    "@types/node": "18.19.69"
   }
 }

--- a/src/__tests__/checkServerIdentity.spec.ts
+++ b/src/__tests__/checkServerIdentity.spec.ts
@@ -31,7 +31,9 @@ const createMockedCertificate = (CN: string): PeerCertificate => ({
     fingerprint256: "MOCKED_FINGERPRINT_256",
     ext_key_usage: ["1.2.3.4.5.6.7.8"],
     serialNumber: "1000",
-    raw: Buffer.from("test")
+    raw: Buffer.from("test"),
+    ca: false,
+    fingerprint512: "MOCKED_FINGERPRINT_512",
 });
 
 describe("Certificate Server Identity", function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,10 +763,12 @@
   dependencies:
     nock "*"
 
-"@types/node@*", "@types/node@14.18.63":
-  version "14.18.63"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+"@types/node@*", "@types/node@18.19.69":
+  version "18.19.69"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.19.69.tgz"
+  integrity sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/prettier@^2.1.5":
   version "2.6.3"
@@ -3608,6 +3610,11 @@ typescript@*, typescript@^4.X.X, typescript@>=2.7, "typescript@>=2.8.0 || >= 3.2
   version "4.9.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR updates the optional dependency @types/node to version18.19.69 to ensure compatibility with recent development changes. 