### PR TITLE
Add NPM publish status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+![Node js](https://user-images.githubusercontent.com/62436079/207373079-9cf9377f-f530-4b02-a515-9b64ef7b06e7.png)
+
 # Adyen API library for Node.js 
 [![Build Status](https://github.com/adyen/Adyen-node-api-library/actions/workflows/npmpublish.yml/badge.svg)](https://github.com/Adyen/adyen-node-api-library/actions/workflows/npmpublish.yml)
 [![Coverage Status](https://coveralls.io/repos/github/Adyen/adyen-node-api-library/badge.svg?branch=main)](https://coveralls.io/github/Adyen/adyen-node-api-library?branch=main)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-
-![Node js](https://user-images.githubusercontent.com/62436079/207373079-9cf9377f-f530-4b02-a515-9b64ef7b06e7.png)
-
 # Adyen API library for Node.js 
-![Node.js CI](https://github.com/Adyen/adyen-node-api-library/workflows/Node.js%20CI/badge.svg)
+[![Build Status](https://github.com/adyen/Adyen-node-api-library/actions/workflows/npmpublish.yml/badge.svg)](https://github.com/Adyen/adyen-node-api-library/actions/workflows/npmpublish.yml)
 [![Coverage Status](https://coveralls.io/repos/github/Adyen/adyen-node-api-library/badge.svg?branch=main)](https://coveralls.io/github/Adyen/adyen-node-api-library?branch=main)
 [![Downloads](https://img.shields.io/npm/dm/@adyen/api-library.svg)](https://www.npmjs.com/package/@adyen/api-library)
 ![npm bundle size (scoped)](https://img.shields.io/bundlephobia/minzip/@adyen/api-library.svg)


### PR DESCRIPTION
Update README to add badge with the status of the last run of [NPM Publish](https://github.com/Adyen/adyen-node-api-library/blob/main/.github/workflows/npmpublish.yml) workflow.

Remove badge with the status of the CI workflow: this often fails as PRs from Dependabot and/or Renovate don't have the access to perform the SonarCloud analysis.
