### PR TITLE
Fix HMAC validation for Banking webhooks

### DIFF
--- a/src/__mocks__/notification/accountHolderCreated.json
+++ b/src/__mocks__/notification/accountHolderCreated.json
@@ -1,0 +1,61 @@
+{
+    "data": {
+      "balancePlatform": "YOUR_BALANCE_PLATFORM",
+      "accountHolder": {
+        "contactDetails": {
+          "email": "test@adyen.com",
+          "phone": {
+            "number": "0612345678",
+            "type": "mobile"
+          },
+          "address": {
+            "houseNumberOrName": "23",
+            "city": "Amsterdam",
+            "country": "NL",
+            "postalCode": "12345",
+            "street": "Main Street 1"
+          }
+        },
+        "description": "Shelly Eller",
+        "legalEntityId": "LE00000000000000000001",
+        "reference": "YOUR_REFERENCE-2412C",
+        "capabilities": {
+          "issueCard": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "receiveFromTransferInstrument": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "sendToTransferInstrument": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "sendToBalanceAccount": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          },
+          "receiveFromBalanceAccount": {
+            "enabled": true,
+            "requested": true,
+            "allowed": false,
+            "verificationStatus": "pending"
+          }
+        },
+        "id": "AH00000000000000000001",
+        "status": "active"
+      }
+    },
+    "environment": "test",
+    "timestamp": "2024-12-15T15:42:03+01:00",
+    "type": "balancePlatform.accountHolder.created"
+  }

--- a/src/__tests__/hmacValidator.spec.ts
+++ b/src/__tests__/hmacValidator.spec.ts
@@ -2,7 +2,7 @@ import HmacValidator from "../utils/hmacValidator";
 import {NotificationItem, NotificationRequestItem } from "../typings/notification/models";
 import { ApiConstants } from "../constants/apiConstants";
 import NotificationRequestService from "../notification/notificationRequest";
-const fs = require('fs');
+import { readFileSync } from "fs";
 
 const key = "DFB1EB5485895CFA84146406857104ABB4CBCABDC8AAF103A624C8F6A3EAAB00";
 const expectedSign = "ZNBPtI+oDyyRrLyD1XirkKnQgIAlFc07Vj27TeHsDRE=";
@@ -130,19 +130,19 @@ describe("HMAC Validator", function (): void {
     });
 
     it("should calculate Banking webhook correctly", function (): void {
-        const data = fs.readFileSync('./src/__mocks__/notification/accountHolderCreated.json', 'utf8'); 
+        const data = readFileSync("./src/__mocks__/notification/accountHolderCreated.json", "utf8"); 
         const encrypted = hmacValidator.calculateHmac(data, "11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB");
         
         expect(encrypted).toEqual("UVBzHbDayhfT1XgaRGAkuKvxwoxrLoVCBdfi3WZU8lI=");
     });
 
     it("should validate Banking webhook correctly", function (): void {
-        const hmacKey = "11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB"
-        const hmacSignature = "UVBzHbDayhfT1XgaRGAkuKvxwoxrLoVCBdfi3WZU8lI="
-        const data = fs.readFileSync('./src/__mocks__/notification/accountHolderCreated.json', 'utf8');
+        const hmacKey = "11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB";
+        const hmacSignature = "UVBzHbDayhfT1XgaRGAkuKvxwoxrLoVCBdfi3WZU8lI=";
+        const data = readFileSync("./src/__mocks__/notification/accountHolderCreated.json", "utf8");
         const isValid = hmacValidator.validateHMACSignature(hmacKey, hmacSignature, data);
         
-        expect(isValid).toBeTruthy
+        expect(isValid).toBeTruthy;
     });
 
 });

--- a/src/__tests__/hmacValidator.spec.ts
+++ b/src/__tests__/hmacValidator.spec.ts
@@ -2,6 +2,7 @@ import HmacValidator from "../utils/hmacValidator";
 import {NotificationItem, NotificationRequestItem } from "../typings/notification/models";
 import { ApiConstants } from "../constants/apiConstants";
 import NotificationRequestService from "../notification/notificationRequest";
+const fs = require('fs');
 
 const key = "DFB1EB5485895CFA84146406857104ABB4CBCABDC8AAF103A624C8F6A3EAAB00";
 const expectedSign = "ZNBPtI+oDyyRrLyD1XirkKnQgIAlFc07Vj27TeHsDRE=";
@@ -127,4 +128,21 @@ describe("HMAC Validator", function (): void {
         notification.notificationItems![0].additionalData![ApiConstants.HMAC_SIGNATURE] = "notValidSign";
         expect(hmacValidator.validateHMAC(notification.notificationItems![0], key)).toBeFalsy();
     });
+
+    it("should calculate Banking webhook correctly", function (): void {
+        const data = fs.readFileSync('./src/__mocks__/notification/accountHolderCreated.json', 'utf8'); 
+        const encrypted = hmacValidator.calculateHmac(data, "11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB");
+        
+        expect(encrypted).toEqual("UVBzHbDayhfT1XgaRGAkuKvxwoxrLoVCBdfi3WZU8lI=");
+    });
+
+    it("should validate Banking webhook correctly", function (): void {
+        const hmacKey = "11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB"
+        const hmacSignature = "UVBzHbDayhfT1XgaRGAkuKvxwoxrLoVCBdfi3WZU8lI="
+        const data = fs.readFileSync('./src/__mocks__/notification/accountHolderCreated.json', 'utf8');
+        const isValid = hmacValidator.validateHMACSignature(hmacKey, hmacSignature, data);
+        
+        expect(isValid).toBeTruthy
+    });
+
 });


### PR DESCRIPTION
The existing HMAC validation function `validateBankingHMAC` is incorrect as it inverts the parameters when calculating the signature.
This PR deprecates `validateBankingHMAC` and add a new function `validateHMACSignature`, together with comments/docs and unit testing.

