### PR TITLE
fix: fix possdk base URL

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -50,6 +50,12 @@ class Service {
             {
                 throw new Error("Please provide your unique live url prefix on the setEnvironment() call on the Client.");
             }
+
+            if (url.includes('/possdk/v68')) {
+                return url.replace("https://checkout-test.adyen.com/",
+                  `https://${this.client.liveEndpointUrlPrefix}-checkout-live.adyenpayments.com/`);
+            }
+
             return url.replace("https://checkout-test.adyen.com/",
                     `https://${this.client.liveEndpointUrlPrefix}-checkout-live.adyenpayments.com/checkout/`);
         }


### PR DESCRIPTION
**Description**
Fixes an issue where in the live environment an additional `checkout` path segment is prepended to POSSDK sessions URL

**Issue**
https://github.com/Adyen/adyen-node-api-library/issues/1483

**Context**
https://github.com/Adyen/adyen-java-api-library/blob/6aff026c85932bbd26b3d7fc6999b71f4092d1a9/src/main/java/com/adyen/Service.java#L68
