### PR TITLE
Adding ISSUER_COMMENTS notification event code

### DIFF
--- a/src/typings/notification/notificationRequestItem.ts
+++ b/src/typings/notification/notificationRequestItem.ts
@@ -159,6 +159,7 @@ export namespace NotificationRequestItem {
         Donation = <any> 'DONATION',
         Expire = <any> 'EXPIRE',
         HandledExternally = <any> 'HANDLED_EXTERNALLY',
+        IssuerComments = <any> 'ISSUER_COMMENTS',
         ManualReviewAccept = <any> 'MANUAL_REVIEW_ACCEPT',
         ManualReviewReject = <any> 'MANUAL_REVIEW_REJECT',
         NotificationOfChargeback = <any> 'NOTIFICATION_OF_CHARGEBACK',


### PR DESCRIPTION
**Description**
Adding the ISSUER_COMMENTS notification event code

(https://docs.adyen.com/risk-management/disputes-api/dispute-notifications/#issuer_comments)


[**Tested scenarios**
N/A

**Fixed issue**:  N/A