### PR TITLE
Default timeout for HTTP client

### DIFF
--- a/src/__tests__/httpClient.spec.ts
+++ b/src/__tests__/httpClient.spec.ts
@@ -7,7 +7,7 @@ import HttpClientException from "../httpClient/httpClientException";
 import { binlookup } from "../typings";
 import { ApiConstants } from "../constants/apiConstants";
 import {paymentMethodsSuccess} from "../__mocks__/checkout/paymentMethodsSuccess";
-
+import Config from "../config";
 
 beforeEach((): void => {
     nock.cleanAll();
@@ -178,3 +178,25 @@ describe("HTTP Client", function (): void {
      });
 
 });
+
+describe('Config class', () => {
+    const DEFAULT_TIMEOUT = 30000; // Define the default timeout value
+
+    test('should set default timeout when no timeout is provided', () => {
+        // Instantiate the Config class without passing a timeout
+        const config = new Config();
+
+        // Expect that the timeout is set to the default value (30000)
+        expect(config.connectionTimeoutMillis).toBe(DEFAULT_TIMEOUT);
+    });
+
+    test('should set custom timeout when provided', () => {
+        // Instantiate the Config class with a custom timeout
+        const customTimeout = 50000;
+        const config = new Config({ connectionTimeoutMillis: customTimeout });
+
+        // Expect that the timeout is set to the custom value (50000)
+        expect(config.connectionTimeoutMillis).toBe(customTimeout);
+    });
+});
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,8 @@ interface ConfigConstructor {
     terminalApiLocalEndpoint?: string;
 }
 
+const DEFAULT_TIMEOUT = 30000; // Default timeout value (30 sec)
+
 class Config {
     public username?: string;
     public password?: string;
@@ -31,7 +33,8 @@ class Config {
         if (options.marketPayEndpoint) this.marketPayEndpoint = options.marketPayEndpoint;
         if (options.applicationName) this.applicationName = options.applicationName;
         if (options.apiKey) this.apiKey = options.apiKey;
-        if (options.connectionTimeoutMillis) this.connectionTimeoutMillis = options.connectionTimeoutMillis || 30000;
+        // Set the timeout to DEFAULT_TIMEOUT if not provided
+        this.connectionTimeoutMillis = options.connectionTimeoutMillis ?? DEFAULT_TIMEOUT;
         if (options.certificatePath) this.certificatePath = options.certificatePath;
         if (options.terminalApiCloudEndpoint) this.terminalApiCloudEndpoint = options.terminalApiCloudEndpoint;
         if (options.terminalApiLocalEndpoint) this.terminalApiLocalEndpoint = options.terminalApiLocalEndpoint;

--- a/src/httpClient/httpURLConnectionClient.ts
+++ b/src/httpClient/httpURLConnectionClient.ts
@@ -118,7 +118,15 @@ class HttpURLConnectionClient implements ClientInterface {
         requestOptions.headers[ApiConstants.ADYEN_LIBRARY_NAME] = LibraryConstants.LIB_NAME;
         requestOptions.headers[ApiConstants.ADYEN_LIBRARY_VERSION] = LibraryConstants.LIB_VERSION;
 
-        return httpsRequest(requestOptions);
+        // create a new ClientRequest object
+        const req = httpsRequest(requestOptions);
+
+        // set the timeout on the ClientRequest instance
+        if (requestOptions.timeout) {
+            req.setTimeout(requestOptions.timeout);
+        }
+
+        return req;
     }
 
     private getQuery(params: [string, string][]): string {


### PR DESCRIPTION
This PR defines a default timeout that should be used when the application doesn't set this configuration option.
