### PR TITLE
CI workflow: update to avoid unnecessary executions

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - sdk-automation/models
-      - promote/main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Update CI workflow to:

- run `on push` only on `main` branch (when a PR is merged)
- run `on pull_request` on `main`, SDK Automation Bot PRs and Release bumps