### PR TITLE
Checkout: mark mandatory query parameters

### DIFF
--- a/src/__tests__/checkout.spec.ts
+++ b/src/__tests__/checkout.spec.ts
@@ -563,25 +563,13 @@ describe("Checkout", (): void => {
     });
 
     test("Should delete stored paymentMethod", async (): Promise<void> => {
-        scope.delete("/storedPaymentMethods/12321")
+        scope.delete("/storedPaymentMethods/12321?shopperReference=myShopperReference&merchantAccount=myMerchantAccount")
         .reply(200);
 
         await expect(
-            checkoutService.RecurringApi.deleteTokenForStoredPaymentDetails("12321"),
+            checkoutService.RecurringApi.deleteTokenForStoredPaymentDetails("12321", "myShopperReference", "myMerchantAccount"),
         ).resolves.not.toThrowError();
 
-    });
-
-    test("Should handle request without query parameters for getResultOfPaymentSession", async(): Promise<void> => {
-        scope.get("/sessions/mySessionIdMock")
-        .reply(200, {
-            "id": "CS12345678",
-            "status": "completed"
-        });
-
-        const resultOfPaymentSessionResponse = await checkoutService.PaymentsApi.getResultOfPaymentSession("mySessionIdMock");
-        expect(resultOfPaymentSessionResponse.id).toEqual("CS12345678");
-        expect(resultOfPaymentSessionResponse.status).toEqual(SessionResultResponse.StatusEnum.Completed);
     });
 
     test("Should handle query parameters for getResultOfPaymentSession", async(): Promise<void> => {

--- a/src/__tests__/httpClient.spec.ts
+++ b/src/__tests__/httpClient.spec.ts
@@ -116,21 +116,21 @@ describe("HTTP Client", function (): void {
         
         const scope = nock("https://checkout-test.adyen.com/v71", {
             reqheaders: {
-                'adyen-library-name': (headerValue) => {
+                "adyen-library-name": (headerValue) => {
                     expect(headerValue).toBeTruthy(); 
                     expect(headerValue).toEqual(expectedLibraryName);
                     return true;
                 },
-                'adyen-library-version': (headerValue) => {
+                "adyen-library-version": (headerValue) => {
                     expect(headerValue).toBeTruthy(); 
                     expect(headerValue).toEqual(expectedLibraryVersion);
-                    expect
+                    expect;
                     return true;
                 },
-                'user-agent': (headerValue) => {
+                "user-agent": (headerValue) => {
                     expect(headerValue).toBeTruthy(); 
                     expect(headerValue).toEqual(expectedUserAgent);
-                    expect
+                    expect;
                     return true;
                 }
             }
@@ -153,21 +153,21 @@ describe("HTTP Client", function (): void {
         
         const scope = nock("https://checkout-test.adyen.com/v71", {
             reqheaders: {
-                'adyen-library-name': (headerValue) => {
+                "adyen-library-name": (headerValue) => {
                     expect(headerValue).toBeTruthy(); 
                     expect(headerValue).toEqual(expectedLibraryName);
                     return true;
                 },
-                'adyen-library-version': (headerValue) => {
+                "adyen-library-version": (headerValue) => {
                     expect(headerValue).toBeTruthy(); 
                     expect(headerValue).toEqual(expectedLibraryVersion);
-                    expect
+                    expect;
                     return true;
                 },
-                'user-agent': (headerValue) => {
+                "user-agent": (headerValue) => {
                     expect(headerValue).toBeTruthy(); 
                     expect(headerValue).toEqual(expectedUserAgent);
-                    expect
+                    expect;
                     return true;
                 }
             }
@@ -181,10 +181,10 @@ describe("HTTP Client", function (): void {
 
 });
 
-describe('Config class', () => {
+describe("Config class", () => {
     const DEFAULT_TIMEOUT = 30000; // Define the default timeout value
 
-    test('should set default timeout when no timeout is provided', () => {
+    test("should set default timeout when no timeout is provided", () => {
         // Instantiate the Config class without passing a timeout
         const config = new Config();
 
@@ -192,7 +192,7 @@ describe('Config class', () => {
         expect(config.connectionTimeoutMillis).toBe(DEFAULT_TIMEOUT);
     });
 
-    test('should set custom timeout when provided', () => {
+    test("should set custom timeout when provided", () => {
         // Instantiate the Config class with a custom timeout
         const customTimeout = 50000;
         const config = new Config({ connectionTimeoutMillis: customTimeout });

--- a/src/service.ts
+++ b/src/service.ts
@@ -51,7 +51,7 @@ class Service {
                 throw new Error("Please provide your unique live url prefix on the setEnvironment() call on the Client.");
             }
 
-            if (url.includes('/possdk/v68')) {
+            if (url.includes("/possdk/v68")) {
                 return url.replace("https://checkout-test.adyen.com/",
                   `https://${this.client.liveEndpointUrlPrefix}-checkout-live.adyenpayments.com/`);
             }

--- a/src/services/checkout/paymentsApi.ts
+++ b/src/services/checkout/paymentsApi.ts
@@ -62,7 +62,7 @@ export class PaymentsApi extends Service {
     * @param sessionResult {@link string } The &#x60;sessionResult&#x60; value from the Drop-in or Component.
     * @return {@link SessionResultResponse }
     */
-    public async getResultOfPaymentSession(sessionId: string, sessionResult?: string, requestOptions?: IRequest.Options): Promise<SessionResultResponse> {
+    public async getResultOfPaymentSession(sessionId: string, sessionResult: string, requestOptions?: IRequest.Options): Promise<SessionResultResponse> {
         const endpoint = `${this.baseUrl}/sessions/{sessionId}`
             .replace("{" + "sessionId" + "}", encodeURIComponent(String(sessionId)));
         const resource = new Resource(this, endpoint);

--- a/src/services/checkout/recurringApi.ts
+++ b/src/services/checkout/recurringApi.ts
@@ -36,7 +36,7 @@ export class RecurringApi extends Service {
     * @param shopperReference {@link string } Your reference to uniquely identify this shopper, for example user ID or account ID. Minimum length: 3 characters. &gt; Your reference must not include personally identifiable information (PII), for example name or email address.
     * @param merchantAccount {@link string } Your merchant account.
     */
-    public async deleteTokenForStoredPaymentDetails(storedPaymentMethodId: string, shopperReference?: string, merchantAccount?: string, requestOptions?: IRequest.Options): Promise<void> {
+    public async deleteTokenForStoredPaymentDetails(storedPaymentMethodId: string, shopperReference: string, merchantAccount: string, requestOptions?: IRequest.Options): Promise<void> {
         const endpoint = `${this.baseUrl}/storedPaymentMethods/{storedPaymentMethodId}`
             .replace("{" + "storedPaymentMethodId" + "}", encodeURIComponent(String(storedPaymentMethodId)));
         const resource = new Resource(this, endpoint);

--- a/templates/typescript/api-single.mustache
+++ b/templates/typescript/api-single.mustache
@@ -24,7 +24,7 @@ export class {{classname}} extends Service {
 {{#operation}}
 
 {{>api_summary}}
-    public async {{#vendorExtensions.x-methodName}}{{.}}{{/vendorExtensions.x-methodName}}{{^vendorExtensions.x-methodName}}{{nickname}}{{/vendorExtensions.x-methodName}}({{#pathParams}}{{paramName}}: {{{dataType}}}, {{/pathParams}}{{#bodyParams}}{{paramName}}: {{{dataType}}}, {{/bodyParams}}{{#queryParams}}{{paramName}}?: {{{dataType}}}, {{/queryParams}}requestOptions?: IRequest.Options): Promise<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    public async {{#vendorExtensions.x-methodName}}{{.}}{{/vendorExtensions.x-methodName}}{{^vendorExtensions.x-methodName}}{{nickname}}{{/vendorExtensions.x-methodName}}({{#pathParams}}{{paramName}}: {{{dataType}}}, {{/pathParams}}{{#bodyParams}}{{paramName}}: {{{dataType}}}, {{/bodyParams}}{{#queryParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/queryParams}}requestOptions?: IRequest.Options): Promise<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         const endpoint = `${this.baseUrl}{{{path}}}`{{#pathParams}}
             .replace("{" + "{{baseName}}" + "}", encodeURIComponent(String({{paramName}}))){{/pathParams}};
         const resource = new Resource(this, endpoint);


### PR DESCRIPTION
Query parameters are always marked as Optional, even when the OpenAPI specs define them as required.

This PR updates the Mustache template that generates the method signatures and fixes the Checkout functions that include mandatory query parameters.

Note: other API will be corrected when the SDK automation Bot runs again.

Fix #1479 #1475
