### PR TITLE
Export HttpClientException

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },
-  "author": "Ricardo Ambrogi",
+  "author": "Adyen",
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "27.5.2",

--- a/src/__tests__/httpClientException.spec.ts
+++ b/src/__tests__/httpClientException.spec.ts
@@ -1,0 +1,18 @@
+import { HttpClientException } from "../"; 
+
+describe("HttpClientException", () => {
+  it("should export HttpClientException as a class", () => {
+    expect(typeof HttpClientException).toBe("function");
+
+    const error = new HttpClientException({
+                    message: `HTTP Exception: `,
+                    statusCode: 422,
+                    errorCode: undefined,
+                    responseHeaders: undefined,
+                    responseBody: "{\"status\": 422, \"message\": \"Test error\"}",
+                });
+
+    expect(error).toBeInstanceOf(HttpClientException);
+    expect(error.statusCode).toBe(422);
+  });
+});

--- a/src/__tests__/httpClientException.spec.ts
+++ b/src/__tests__/httpClientException.spec.ts
@@ -1,16 +1,14 @@
-import { HttpClientException } from "../"; 
+import { HttpClientException } from "../";
 
 describe("HttpClientException", () => {
   it("should export HttpClientException as a class", () => {
     expect(typeof HttpClientException).toBe("function");
 
     const error = new HttpClientException({
-                    message: `HTTP Exception: `,
-                    statusCode: 422,
-                    errorCode: undefined,
-                    responseHeaders: undefined,
-                    responseBody: "{\"status\": 422, \"message\": \"Test error\"}",
-                });
+      message: "Test error",
+      statusCode: 422,
+      responseBody: JSON.stringify({ status: 422, message: "Test error" }),
+    });
 
     expect(error).toBeInstanceOf(HttpClientException);
     expect(error.statusCode).toBe(422);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,6 @@ export { default as Config } from "./config";
 export * from "./services/";
 export { hmacValidator } from "./utils";
 export { default as HttpURLConnectionClient } from "./httpClient/httpURLConnectionClient";
+export { default as HttpClientException } from "./httpClient/httpClientException";
 export * as Types from "./typings";
 


### PR DESCRIPTION
Following the great feedback in #1420 the library now exports `HttpClientException`, allowing to `try-catch` the Adyen API exceptions without importing directly from the path

Fix #1420 

