### PR TITLE
Update additionalData definition

### DIFF
--- a/src/__tests__/webhooks/notification.spec.ts
+++ b/src/__tests__/webhooks/notification.spec.ts
@@ -141,4 +141,26 @@ describe("Notification Tests", function (): void {
         expect(notificationRequestItem.additionalData["metadata.anotherKey"]).toEqual("anotherValue");
 
     });
+    
+});
+
+describe('NotificationRequestItem.additionalData', () => {
+  it('handles undefined keys', () => {
+    const item: NotificationRequestItem = {
+        additionalData: { 
+            existingKey: "abc",
+            undefinedKey: undefined
+         },
+        amount: { currency: "EUR", value: 1000 },
+        pspReference: "",
+        eventCode: NotificationRequestItem.EventCodeEnum.Authorisation,
+        eventDate: "",
+        merchantAccountCode: "",
+        merchantReference: "",
+        success: NotificationRequestItem.SuccessEnum.True
+    };
+    expect(item.additionalData?.['existingKey']).toBeDefined();
+    expect(item.additionalData?.['undefinedKey']).toBeUndefined();
+    expect(item.additionalData?.['nonExistingKey']).toBeUndefined();
+  });
 });

--- a/src/typings/notification/notificationRequestItem.ts
+++ b/src/typings/notification/notificationRequestItem.ts
@@ -32,7 +32,7 @@
 import { Amount } from './amount';
 
 export class NotificationRequestItem {
-    'additionalData'?: { [key: string]: string; };
+    'additionalData'?: { [key: string]: string | undefined; };
     'amount': Amount;
     /**
     * Adyen\'s 16-character unique reference associated with the transaction/the request. This value is globally unique; quote it when communicating with us about this request.


### PR DESCRIPTION
Update the definition of `NotificationRequestItem.additionalData` to expect `undefined` values in the map

Fix #1539
