### PR TITLE
fix(TAPI): Correct live endpoints for Terminal API

### DIFF
--- a/src/__tests__/client.spec.ts
+++ b/src/__tests__/client.spec.ts
@@ -101,7 +101,7 @@ describe("API Client", function (): void {
     });
     const client = new Client(config);
     expect(client.config.terminalApiCloudEndpoint).toBeDefined();
-    expect(client.config.terminalApiCloudEndpoint).toBe("https://terminal-api-us.adyen.com");
+    expect(client.config.terminalApiCloudEndpoint).toBe("https://terminal-api-live-us.adyen.com");
   });
 
   test("should set and get custom http client", () => {
@@ -156,4 +156,3 @@ describe("API Client", function (): void {
   });
 
 });
-

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,9 @@ export const TERMINAL_API_ENDPOINT_TEST = "https://terminal-api-test.adyen.com";
 
 // Live endpoints for Terminal API
 const TERMINAL_API_ENDPOINT_LIVE = "https://terminal-api-live.adyen.com";
-const TERMINAL_API_ENDPOINT_AU_LIVE = "https://terminal-api-au.adyen.com";
-const TERMINAL_API_ENDPOINT_US_LIVE = "https://terminal-api-us.adyen.com";
-const TERMINAL_API_ENDPOINT_APSE_LIVE = "https://terminal-api-apse.adyen.com";
+const TERMINAL_API_ENDPOINT_AU_LIVE = "https://terminal-api-live-au.adyen.com";
+const TERMINAL_API_ENDPOINT_US_LIVE = "https://terminal-api-live-us.adyen.com";
+const TERMINAL_API_ENDPOINT_APSE_LIVE = "https://terminal-api-live-apse.adyen.com";
 
 
 /**
@@ -66,7 +66,7 @@ class Config {
     public terminalApiCloudEndpoint?: string;
     public terminalApiLocalEndpoint?: string;
     public liveEndpointUrlPrefix?: string;
-    public region?: RegionEnum;     
+    public region?: RegionEnum;
 
     public constructor(options: ConfigConstructor = {}) {
         if (options.username) this.username = options.username;


### PR DESCRIPTION
As per https://docs.adyen.com/point-of-sale/design-your-integration/terminal-api/#live-endpoints these should be `terminal-api-live-{region}.adyen.com` for us, au and apse regions. Whereas previously, us and au were incorrectly set to `terminal-api-{region}.adyen.com`, missing the `-live` part.
