### PR TITLE
Feature/add locked currency to platform payment config

### DIFF
--- a/src/__tests__/platformPaymentConfiguration.spec.ts
+++ b/src/__tests__/platformPaymentConfiguration.spec.ts
@@ -1,0 +1,38 @@
+import { PlatformPaymentConfiguration } from "../typings/balancePlatform/platformPaymentConfiguration";
+import { BalanceAccountInfo } from "../typings/balancePlatform/balanceAccountInfo";
+
+describe("PlatformPaymentConfiguration", (): void => {
+    describe("lockedCurrency field", (): void => {
+        it("should support lockedCurrency property", (): void => {
+            const config = new PlatformPaymentConfiguration();
+            config.lockedCurrency = "CAD";
+            config.salesDayClosingTime = "02:00";
+            config.settlementDelayDays = 3;
+
+            expect(config.lockedCurrency).toBe("CAD");
+            expect(config.salesDayClosingTime).toBe("02:00");
+            expect(config.settlementDelayDays).toBe(3);
+        });
+
+        it("should include lockedCurrency in attributeTypeMap", (): void => {
+            const attributeTypeMap = PlatformPaymentConfiguration.getAttributeTypeMap();
+            const lockedCurrencyAttr = attributeTypeMap.find(attr => attr.name === "lockedCurrency");
+            
+            expect(lockedCurrencyAttr).toBeDefined();
+            expect(lockedCurrencyAttr?.baseName).toBe("lockedCurrency");
+            expect(lockedCurrencyAttr?.type).toBe("string");
+        });
+
+        it("should work with BalanceAccountInfo", (): void => {
+            const balanceAccountInfo = new BalanceAccountInfo();
+            balanceAccountInfo.accountHolderId = "AH123456";
+            
+            const platformConfig = new PlatformPaymentConfiguration();
+            platformConfig.lockedCurrency = "CAD";
+            
+            balanceAccountInfo.platformPaymentConfiguration = platformConfig;
+            
+            expect(balanceAccountInfo.platformPaymentConfiguration?.lockedCurrency).toBe("CAD");
+        });
+    });
+});

--- a/src/typings/balancePlatform/platformPaymentConfiguration.ts
+++ b/src/typings/balancePlatform/platformPaymentConfiguration.ts
@@ -10,7 +10,11 @@
 
 export class PlatformPaymentConfiguration {
     /**
-    * The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes) to lock the balance account to. Once set, all transactions for this balance account must be in this currency.
+    * Three-letter [ISO currency code](https://docs.adyen.com/development-resources/currency-codes) 
+    * to lock the balance account to.  
+    * 
+    * By default, FX is not applied to the `PaymentFee` split type.  
+    * Setting this field enables FX for `PaymentFee` as well.
     */
     "lockedCurrency"?: string;
     /**

--- a/src/typings/balancePlatform/platformPaymentConfiguration.ts
+++ b/src/typings/balancePlatform/platformPaymentConfiguration.ts
@@ -10,6 +10,10 @@
 
 export class PlatformPaymentConfiguration {
     /**
+    * The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes) to lock the balance account to. Once set, all transactions for this balance account must be in this currency.
+    */
+    "lockedCurrency"?: string;
+    /**
     * Specifies at what time a sales day ends for this account.  Possible values: Time in **\"HH:MM\"** format. **HH** ranges from **00** to **07**. **MM** must be **00**.  Default value: **\"00:00\"**.
     */
     "salesDayClosingTime"?: string;
@@ -23,6 +27,12 @@ export class PlatformPaymentConfiguration {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "lockedCurrency",
+            "baseName": "lockedCurrency",
+            "type": "string",
+            "format": ""
+        },
         {
             "name": "salesDayClosingTime",
             "baseName": "salesDayClosingTime",


### PR DESCRIPTION
**Description**
Per Adyen’s IM, setting `lockedCurrency` when creating a balance account ensures fees are FX-converted to the specified currency. Since this property isn’t available in the SDK, this PR adds it to `PlatformPaymentConfiguration`.

**Tested scenarios**
Support for locked currency property

**Fixed issue**:  <!-- #-prefixed issue number -->
N/A