### PR TITLE
Sonarcloud Workflow: Change npm ci to npm install in workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run tests with coverage
         run: npm run test:coverage


### PR DESCRIPTION
The [Sonarcloud](https://github.com/Adyen/adyen-node-api-library/actions/runs/18361332812/job/52305431528) workflow fails because there is no `package-lock.json`.
This PR updates the workflow to use `npm install` (creating the lock file) instead of `npm ci` (which has no benefits/value compare to npm install).
