### PR TITLE
feat!: add region validation for Terminal Cloud API

### DIFF
--- a/src/__mocks__/base.ts
+++ b/src/__mocks__/base.ts
@@ -18,7 +18,7 @@
  */
 
 import Client from "../client";
-import Config, { EnvironmentEnum } from "../config";
+import Config, { EnvironmentEnum, RegionEnum } from "../config";
 import {
     AmountsReq,
     MessageCategoryType,
@@ -38,6 +38,7 @@ import {
 export const createClient = (apiKey = process.env.ADYEN_API_KEY): Client => {
     const config: Config = new Config();
     config.environment = EnvironmentEnum.TEST;
+    config.region = RegionEnum.EU;
     config.terminalApiCloudEndpoint = Client.TERMINAL_API_ENDPOINT_TEST;
     config.terminalApiLocalEndpoint = "https://mocked_local_endpoint.com";
     config.marketPayEndpoint = Client.MARKETPAY_ENDPOINT_TEST;

--- a/src/__tests__/terminalCloudAPI.spec.ts
+++ b/src/__tests__/terminalCloudAPI.spec.ts
@@ -5,7 +5,7 @@ import { syncRefund, syncRes, syncResEventNotification, syncResEventNotification
 import Client from "../client";
 import TerminalCloudAPI from "../services/terminalCloudAPI";
 import { terminal } from "../typings";
-import { EnvironmentEnum } from "../config";
+import { EnvironmentEnum, RegionEnum } from "../config";
 import HttpClientException from "../httpClient/httpClientException";
 
 let client: Client;
@@ -27,6 +27,26 @@ afterEach((): void => {
 });
 
 describe("Terminal Cloud API", (): void => {
+  test("should throw error when region is not specified", (): void => {
+    const clientWithoutRegion = new Client({
+      apiKey: "YOUR_API_KEY",
+      environment: EnvironmentEnum.TEST
+    });
+
+    expect(() => new TerminalCloudAPI(clientWithoutRegion))
+      .toThrow("Region is required for Terminal API");
+  });
+
+  test("should initialize successfully with region", (): void => {
+    const clientWithRegion = new Client({
+      apiKey: "YOUR_API_KEY",
+      environment: EnvironmentEnum.TEST,
+      region: RegionEnum.EU
+    });
+
+    expect(() => new TerminalCloudAPI(clientWithRegion)).not.toThrow();
+  });
+
   test("should make an async payment request", async (): Promise<void> => {
     scope.post("/async").reply(200, asyncRes);
 
@@ -141,7 +161,7 @@ describe("Terminal Cloud API", (): void => {
 
     const terminalApiHost = "https://terminal-api-test.adyen.com";
 
-    const client = new Client({ apiKey: "YOUR_API_KEY", environment: EnvironmentEnum.TEST });
+    const client = new Client({ apiKey: "YOUR_API_KEY", environment: EnvironmentEnum.TEST, region: RegionEnum.EU });
     const terminalCloudAPI = new TerminalCloudAPI(client);
 
     const terminalAPIPaymentRequest = createTerminalAPIPaymentRequest();
@@ -168,7 +188,7 @@ describe("Terminal Cloud API", (): void => {
   test("sync should validate 308 location header", async (): Promise<void> => {
     const terminalApiHost = "https://terminal-api-test.adyen.com";
 
-    const client = new Client({ apiKey: "YOUR_API_KEY", environment: EnvironmentEnum.TEST });
+    const client = new Client({ apiKey: "YOUR_API_KEY", environment: EnvironmentEnum.TEST, region: RegionEnum.EU });
 
     const terminalCloudAPI = new TerminalCloudAPI(client);
 
@@ -203,10 +223,9 @@ describe("Terminal Cloud API", (): void => {
   });
 
   test("async should skip 308 redirect", async (): Promise<void> => {
-    
     const terminalApiHost = "https://terminal-api-test.adyen.com";
 
-    const client = new Client({ apiKey: "YOUR_API_KEY", environment: EnvironmentEnum.TEST, enable308Redirect: false });
+    const client = new Client({ apiKey: "YOUR_API_KEY", environment: EnvironmentEnum.TEST, region: RegionEnum.EU, enable308Redirect: false });
     const terminalCloudAPI = new TerminalCloudAPI(client);
 
     const terminalAPIPaymentRequest = createTerminalAPIPaymentRequest();

--- a/src/services/terminalCloudAPI.ts
+++ b/src/services/terminalCloudAPI.ts
@@ -32,6 +32,11 @@ class TerminalCloudAPI extends Service {
 
     public constructor(client: Client) {
         super(client);
+
+        if (!client.config.region) {
+          throw new Error("Region is required for Terminal API");
+        }
+
         this.apiKeyRequired = true;
         this.terminalApiAsync = new Async(this);
         this.terminalApiSync = new Sync(this);


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

This PR introduces a **breaking change** that requires the `region` parameter when using the Terminal Cloud API.

## Summary

- Add mandatory region validation for `TerminalCloudAPI` initialization
- Throw a clear error message when region is not specified
- Update all tests to include region parameter
- Add new test cases to verify region validation behavior

## Why this change?

The Terminal Cloud API endpoints are region-specific, and the library already supports multiple regions (EU, AU, US, APSE). However, the region parameter was optional, which could lead to:
- Runtime errors when the wrong endpoint is used
- Confusion about which endpoint is being called
- Potential issues with region-specific features

Making the region parameter mandatory at initialization time provides:
- ✅ Clear error messages at construction time (fail-fast)
- ✅ Explicit regional endpoint configuration
- ✅ Better developer experience with early validation

## Breaking Change Details

### Before (v30.0.0)
```typescript
const client = new Client({
  apiKey: "YOUR_API_KEY",
  environment: EnvironmentEnum.TEST
});

const terminalAPI = new TerminalCloudAPI(client); // This was allowed
```

### After (this PR)
```typescript
import { RegionEnum } from '@adyen/api-library';

const client = new Client({
  apiKey: "YOUR_API_KEY",
  environment: EnvironmentEnum.TEST,
  region: RegionEnum.EU  // ⚠️ Now required for Terminal API
});

const terminalAPI = new TerminalCloudAPI(client); // ✅ Works
```
