### PR TITLE
Fix SessionAuthentication LIVE url

### DIFF
--- a/src/__tests__/service.spec.ts
+++ b/src/__tests__/service.spec.ts
@@ -131,4 +131,31 @@ describe("Service", () => {
         const url = "https://some-test.adyen.com/api/";
         expect(service.testCreateBaseUrl(url)).toBe("https://some-live.adyen.com/api/");
     });
-});
+
+    it("should build TEST url for SessionAuthentication", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.TEST,
+            liveEndpointUrlPrefix: "mycompany"
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://test.adyen.com/authe/api/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://test.adyen.com/authe/api/v1");
+    });
+
+    it("should build LIVE url for SessionAuthentication", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.LIVE,
+            liveEndpointUrlPrefix: "mycompany"
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://test.adyen.com/authe/api/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://authe-live.adyen.com/authe/api/v1");
+    });
+
+});  

--- a/src/service.ts
+++ b/src/service.ts
@@ -58,6 +58,10 @@ class Service {
             }
         }
 
+        if (url.includes("/authe/")) {
+            return url.replace("https://test.adyen.com/", "https://authe-live.adyen.com/");
+        }
+
         if (url.includes("pal-")) {
             return url.replace("https://pal-test.adyen.com/pal/servlet/",
                     `https://${this.client.config.liveEndpointUrlPrefix}-pal-live.adyenpayments.com/pal/servlet/`);


### PR DESCRIPTION
The `live` url of the [SessionAuthentication](https://docs.adyen.com/api-explorer/sessionauthentication/1/overview) API is incorrect: this PR fixes the bug and adds a test.

This is a short-term solution, we will revise the approach and use the url from the OpenAPI `servers` element.

Fix #1578 