### PR TITLE
Remove @Adyen/developer-relations from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Adyen/developer-relations  @Adyen/api-library-maintainers
+* @Adyen/api-library-maintainers


### PR DESCRIPTION
Remove `@Adyen/developer-relations` from CODEOWNERS, keeping only `@Adyen/api-library-maintainers`.