### PR TITLE
Fix incorrect serialisation of Set types in ObjectSerializer

### DIFF
--- a/src/__tests__/sessionAuthenticationApi.spec.ts
+++ b/src/__tests__/sessionAuthenticationApi.spec.ts
@@ -2,7 +2,7 @@ import nock from "nock";
 import { createClient } from "../__mocks__/base";
 import SessionAuthenticationApi from "../services/sessionAuthentication";
 import Client from "../client";
-import { AuthenticationSessionRequest, AuthenticationSessionResponse, ProductType, ResourceType } from "../typings/sessionAuthentication/models";
+import { AccountHolderResource, AuthenticationSessionRequest, AuthenticationSessionResponse, ObjectSerializer, Policy, ProductType, ResourceType } from "../typings/sessionAuthentication/models";
 
 let client: Client;
 let sessionAuthenticationApi: SessionAuthenticationApi;
@@ -50,5 +50,61 @@ describe("SessionAuthenticationApi", (): void => {
 
         expect(result).toBeTruthy();
         expect(result.token).toBe("ABCDEFGHIJKLMNOP");
+    });
+
+    test("should serialise Set<string> and Set<Resource> as arrays in the request body", async (): Promise<void> => {
+        const mockResponse: AuthenticationSessionResponse = {
+            id: "12345678",
+            token: "ABCDEFGHIJKLMNOP",
+        };
+
+        let capturedBody: Record<string, unknown> = {};
+        scope.post("/sessions").reply(200, function (_uri, body) {
+            capturedBody = body as Record<string, unknown>;
+            return mockResponse;
+        });
+
+        const accountHolderResource = {
+            type: ResourceType.AccountHolder,
+            accountHolderId: "AH123456789",
+        };
+
+        const request: AuthenticationSessionRequest = {
+            allowOrigin: "https://your-merchant-website.com",
+            policy: {
+                resources: new Set([accountHolderResource]),
+                roles: new Set(["onboarding", "verification"]),
+            },
+            product: ProductType.Platform,
+        };
+
+        await sessionAuthenticationApi.SessionAuthenticationApi.createAuthenticationSession(request);
+
+        const policy = capturedBody["policy"] as Record<string, unknown>;
+
+        // Sets must be serialised as arrays, not as empty objects ({})
+        expect(Array.isArray(policy["roles"])).toBe(true);
+        expect(policy["roles"]).toEqual(["onboarding", "verification"]);
+        expect(Array.isArray(policy["resources"])).toBe(true);
+        expect(policy["resources"]).toEqual([{ type: ResourceType.AccountHolder, accountHolderId: "AH123456789" }]);
+    });
+
+    test("should deserialise arrays in Policy JSON into Set instances", (): void => {
+        const raw = {
+            roles: ["onboarding", "verification"],
+            resources: [
+                { type: ResourceType.AccountHolder, accountHolderId: "AH123456789" },
+            ],
+        };
+
+        const policy: Policy = ObjectSerializer.deserialize(raw, "Policy");
+
+        expect(policy.roles).toBeInstanceOf(Set);
+        expect(policy.roles).toEqual(new Set(["onboarding", "verification"]));
+        expect(policy.resources).toBeInstanceOf(Set);
+        const expectedResource = new AccountHolderResource();
+        expectedResource.type = ResourceType.AccountHolder;
+        expectedResource.accountHolderId = "AH123456789";
+        expect(policy.resources).toEqual(new Set([expectedResource]));
     });
 });

--- a/src/typings/sessionAuthentication/objectSerializer.ts
+++ b/src/typings/sessionAuthentication/objectSerializer.ts
@@ -101,6 +101,7 @@ const nullableSuffix = " | null";
 const optionalSuffix = " | undefined";
 const arrayPrefix = "Array<";
 const arraySuffix = ">";
+const setPrefix = "Set<";
 const mapPrefix = "{ [key: string]: ";
 const mapSuffix = "; }";
 
@@ -170,6 +171,13 @@ export class ObjectSerializer {
             let transformedData: any[] = [];
             for (let date of data) {
                 transformedData.push(ObjectSerializer.serialize(date, subType, format));
+            }
+            return transformedData;
+        } else if (type.startsWith(setPrefix)) {
+            let subType: string = type.slice(setPrefix.length, -arraySuffix.length); // Set<Type> => Type
+            let transformedData: any[] = [];
+            for (let item of data) {
+                transformedData.push(ObjectSerializer.serialize(item, subType, format));
             }
             return transformedData;
         } else if (type.startsWith(mapPrefix)) {
@@ -252,6 +260,13 @@ export class ObjectSerializer {
             let transformedData: any[] = [];
             for (let date of data) {
                 transformedData.push(ObjectSerializer.deserialize(date, subType, format));
+            }
+            return transformedData;
+        } else if (type.startsWith(setPrefix)) {
+            let subType: string = type.slice(setPrefix.length, -arraySuffix.length); // Set<Type> => Type
+            let transformedData = new Set<any>();
+            for (let item of data) {
+                transformedData.add(ObjectSerializer.deserialize(item, subType, format));
             }
             return transformedData;
         } else if (type.startsWith(mapPrefix)) {

--- a/templates-v7/typescript/model/ObjectSerializer.mustache
+++ b/templates-v7/typescript/model/ObjectSerializer.mustache
@@ -109,6 +109,7 @@ const nullableSuffix = " | null";
 const optionalSuffix = " | undefined";
 const arrayPrefix = "Array<";
 const arraySuffix = ">";
+const setPrefix = "Set<";
 const mapPrefix = "{ [key: string]: ";
 const mapSuffix = "; }";
 
@@ -178,6 +179,13 @@ export class ObjectSerializer {
             let transformedData: any[] = [];
             for (let date of data) {
                 transformedData.push(ObjectSerializer.serialize(date, subType, format));
+            }
+            return transformedData;
+        } else if (type.startsWith(setPrefix)) {
+            let subType: string = type.slice(setPrefix.length, -arraySuffix.length); // Set<Type> => Type
+            let transformedData: any[] = [];
+            for (let item of data) {
+                transformedData.push(ObjectSerializer.serialize(item, subType, format));
             }
             return transformedData;
         } else if (type.startsWith(mapPrefix)) {
@@ -260,6 +268,13 @@ export class ObjectSerializer {
             let transformedData: any[] = [];
             for (let date of data) {
                 transformedData.push(ObjectSerializer.deserialize(date, subType, format));
+            }
+            return transformedData;
+        } else if (type.startsWith(setPrefix)) {
+            let subType: string = type.slice(setPrefix.length, -arraySuffix.length); // Set<Type> => Type
+            let transformedData = new Set<any>();
+            for (let item of data) {
+                transformedData.add(ObjectSerializer.deserialize(item, subType, format));
             }
             return transformedData;
         } else if (type.startsWith(mapPrefix)) {


### PR DESCRIPTION
## Description
`ObjectSerializer.serialize` and `ObjectSerializer.deserialize` had no handling for `Set<T>` types. When a field was typed as `Set<Resource>` or `Set<string>`, the type string fell through to an unmatched `typeMap` lookup, returning the raw `Set` object. `JSON.stringify` on a `Set` produces `{}`, causing requests like:

```json
{ "policy": { "resources": {}, "roles": {} } }
```

instead of the expected arrays.

## Changes
- Added `Set<T>` branch in `ObjectSerializer.serialize`: iterates the Set and returns a plain array (enabling correct JSON serialisation)
- Added `Set<T>` branch in `ObjectSerializer.deserialize`: iterates the incoming array and wraps the result in a `new Set`
- Applied both fixes to the Mustache template (`templates-v7/typescript/model/ObjectSerializer.mustache`) so all future generated serializers are covered
- Applied the same fix to the currently generated `src/typings/sessionAuthentication/objectSerializer.ts` (the only service using `Set<T>` today)

## Tested scenarios
- `Set<string>` (roles) and `Set<Resource>` (resources) are serialised as arrays in the HTTP request body
- JSON arrays in a response/payload are deserialised back into `Set` instances via `ObjectSerializer.deserialize`
- Full test suite (42 suites, 474 tests) passes with no regressions

## Fixed issue
Fixes #1640