### PR TITLE
Fix lodash-es prototype pollution vulnerability 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4366,9 +4366,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/node": "18.19.69"
   },
   "overrides": {
-    "lodash": "^4.18.0"
+    "lodash": "^4.18.0",
+    "lodash-es": "^4.18.0"
   }
 }


### PR DESCRIPTION
## Description
Add `lodash-es` to npm overrides to fix prototype pollution vulnerability (CVE-2025-13465 bypass).

`ts-auto-mock@3.7.4` pins `lodash-es` to `4.17.21`, which is vulnerable to prototype pollution via array path bypass in `_.unset` and `_.omit`. The existing overrides only covered `lodash` (CJS), not `lodash-es` (ESM).

## Tested scenarios
- All 472 unit tests pass

## Fixed issue
VAST-1722