### PR TITLE
Fix picomatch vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4785,9 +4785,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "overrides": {
     "lodash": "^4.18.0",
-    "lodash-es": "^4.18.0"
+    "lodash-es": "^4.18.0",
+    "picomatch": "^2.3.2"
   }
 }


### PR DESCRIPTION
## Description
Upgrades `picomatch` from `2.3.1` to `2.3.2` via `overrides` in `package.json` to address a method injection vulnerability in POSIX character classes (CWE-1321).

The vulnerability allows specially crafted glob patterns (e.g. `[[:constructor:]]`) to reference inherited `Object.prototype` methods, causing incorrect glob matching behavior. This affects any application relying on glob patterns for filtering, validation, or access control.

## Tested scenarios
- All 472 existing tests pass after the upgrade

## Fixed issue
Fixes VAST-1641