### PR TITLE
Fix standalone enum registration in ObjectSerializer enumsMap

### DIFF
--- a/src/__tests__/checkoutObjectSerializer.spec.ts
+++ b/src/__tests__/checkoutObjectSerializer.spec.ts
@@ -1,0 +1,39 @@
+import { ObjectSerializer, Result, ValidateShopperIdResponse } from "../typings/checkout/objectSerializer";
+
+describe("ObjectSerializer - standalone enum (Result)", () => {
+
+    it("should recognize Result as an enum type via findCorrectType", () => {
+        const type = ObjectSerializer.findCorrectType(Result.Valid, "Result");
+        expect(type).toBe("Result");
+    });
+
+    it("should serialize ValidateShopperIdResponse with a Result enum field", () => {
+        const input: ValidateShopperIdResponse = new ValidateShopperIdResponse();
+        input.result = Result.Valid;
+        input.reason = "ok";
+
+        const serialized = ObjectSerializer.serialize(input, "ValidateShopperIdResponse");
+
+        expect(serialized).toHaveProperty("result", "VALID");
+        expect(serialized).toHaveProperty("reason", "ok");
+    });
+
+    it("should deserialize a ValidateShopperIdResponse with a Result enum field", () => {
+        const raw = { result: "VALID", reason: "ok" };
+
+        const deserialized = ObjectSerializer.deserialize(raw, "ValidateShopperIdResponse") as ValidateShopperIdResponse;
+
+        expect(deserialized.result).toBe("VALID");
+        expect(deserialized.reason).toBe("ok");
+    });
+
+    it("should round-trip serialize then deserialize a Result enum value", () => {
+        const input: ValidateShopperIdResponse = new ValidateShopperIdResponse();
+        input.result = Result.Invalid;
+
+        const serialized = ObjectSerializer.serialize(input, "ValidateShopperIdResponse");
+        const deserialized = ObjectSerializer.deserialize(serialized, "ValidateShopperIdResponse") as ValidateShopperIdResponse;
+
+        expect(deserialized.result).toBe(Result.Invalid);
+    });
+});

--- a/src/typings/checkout/objectSerializer.ts
+++ b/src/typings/checkout/objectSerializer.ts
@@ -194,7 +194,6 @@ import { ResponseAdditionalDataOpi } from "./responseAdditionalDataOpi";
 import { ResponseAdditionalDataSepa } from "./responseAdditionalDataSepa";
 import { ResponseAdditionalDataSwish } from "./responseAdditionalDataSwish";
 import { ResponsePaymentMethod } from "./responsePaymentMethod";
-import { Result } from "./result";
 import { RiskData } from "./riskData";
 import { RivertyDetails } from "./rivertyDetails";
 import { SDKEphemPubKey } from "./sDKEphemPubKey";
@@ -425,9 +424,7 @@ let enumsMap: Set<string> = new Set<string>([
     "ResponseAdditionalDataCommon.FraudRiskLevelEnum",
     "ResponseAdditionalDataCommon.RecurringProcessingModelEnum",
     "ResponseAdditionalDataCommon.TokenizationStoreOperationTypeEnum",
-    Result.Valid,
-    Result.Invalid,
-    Result.Unknown,
+    "Result",
     "RivertyDetails.TypeEnum",
     "SamsungPayDetails.FundingSourceEnum",
     "SamsungPayDetails.TypeEnum",

--- a/templates-v7/typescript/model/ObjectSerializer.mustache
+++ b/templates-v7/typescript/model/ObjectSerializer.mustache
@@ -6,7 +6,9 @@ export * from "./models";
 
 {{#models}}
 {{#model}}
+{{^isEnum}}
 import { {{classname}}{{#oneOf}}{{#-first}}Class{{/-first}}{{/oneOf}} } from "./{{#lambda.camelcase}}{{ classname }}{{/lambda.camelcase}}{{importFileExtension}}";
+{{/isEnum}}
 {{/model}}
 {{/models}}
 
@@ -26,11 +28,7 @@ let enumsMap: Set<string> = new Set<string>([
     {{#models}}
         {{#model}}
             {{#isEnum}}
-                {{#allowableValues}}
-                    {{#enumVars}}
-    {{classname}}.{{name}},
-                    {{/enumVars}}
-                {{/allowableValues}}
+    "{{classname}}",
             {{/isEnum}}
             {{#hasEnums}}
                 {{#vars}}


### PR DESCRIPTION
## Description

In `objectSerializer.ts` files, standalone enums (top-level `export enum`) were incorrectly registered in `enumsMap` using their runtime values (e.g. `Result.Valid` → `'VALID'`) instead of the type name string (e.g. `"Result"`). The serializer checks `enumsMap.has(type)` where `type` is the type name string, so those lookups always returned `false` and standalone enums were never recognised as enum types.

## Notes
The issue effectively didn't create a problem since the enum value deserialization returns data as-is (the value found in the JSON payload) when a value cannot be mapped to an enum.

**Changes:**
- **Mustache template** (`templates-v7/typescript/model/ObjectSerializer.mustache`): replace the per-value iteration inside `{{#isEnum}}` with a single type name string entry; also skip generating imports for standalone enums since they are no longer referenced in the file body after this fix.
- **`src/typings/checkout/objectSerializer.ts`** (manual, matching generated output): replace `Result.Valid`, `Result.Invalid`, `Result.Unknown` with `"Result"`; remove the now-unused `import { Result }`.
- **New test** (`src/__tests__/checkoutObjectSerializer.spec.ts`): covers `findCorrectType`, serialize, deserialize, and round-trip for a `ValidateShopperIdResponse` with a `Result` field.

Checkout `objectSerializer.ts` has been updated manually to run new tests, all other `objectSerializer.ts` files will be updated by the SDK Automation generation.


## Fixed issue

Fixes #1659