### PR TITLE
Configure trusted publishing on NPM

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -4,11 +4,17 @@ name: Publish to NPM
 
 on:
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Skip publishing to NPM (runs npm whoami instead)'
+        type: boolean
+        default: false
   release:
     types: [published]
 
 permissions:
   contents: read
+  id-token: write # Required for OpenID Connect (OIDC) for trusted publishing on NPM
 
 jobs:
   build:
@@ -17,7 +23,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: '18.x'
+          node-version: '24'
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Build package
@@ -39,15 +45,18 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: '18.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
+          package-manager-cache: false  # never use caching in release builds
       - name: Download build artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: build-output
           path: lib/
       - name: Publish to NPM
+        if: ${{ inputs.dry-run != 'true' }}
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ADYEN_NODE_API_LIBRARY_TOKEN }}
+      - name: Dry run (verify publish without uploading)
+        if: ${{ inputs.dry-run == 'true' }}
+        run: npm publish --dry-run


### PR DESCRIPTION
## Description
Configures [trusted publishing](https://docs.npmjs.com/trusted-publishers) on NPM.
Adds an optional `dry-run` boolean input (default: `false`) to the `workflow_dispatch` trigger of the NPM publish workflow.
