### PR TITLE
Fix dry-run condition and invalid setup-node input in NPM publish workflow

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       dry-run:
-        description: 'Skip publishing to NPM (runs npm whoami instead)'
+        description: 'Run npm publish --dry-run instead of publishing to NPM'
         type: boolean
         default: false
   release:
@@ -48,15 +48,14 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
-          package-manager-cache: false  # never use caching in release builds
       - name: Download build artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: build-output
           path: lib/
       - name: Publish to NPM
-        if: ${{ inputs.dry-run != 'true' }}
+        if: ${{ !fromJSON(inputs.dry-run || 'false') }}
         run: npm publish
       - name: Dry run (verify publish without uploading)
-        if: ${{ inputs.dry-run == 'true' }}
+        if: ${{ fromJSON(inputs.dry-run || 'false') }}
         run: npm publish --dry-run


### PR DESCRIPTION
## Description
Fixes two issues in the NPM publish workflow introduced in bc0e9cb:

1. **Dry-run condition bug**: `inputs.dry-run != 'true'` does not reliably handle `type: boolean` workflow_dispatch inputs, which can be passed as native booleans rather than strings. Replaced with `fromJSON(inputs.dry-run || 'false')` for correct evaluation in all trigger scenarios (workflow_dispatch with true/false, and release event where inputs is absent).

2. **Invalid `package-manager-cache` input**: This is not a valid input for `actions/setup-node@v4.1.0`, causing a warning on every run. Removed it (caching is off by default when the `cache` input is not set).

3. **Misleading input description**: Updated to accurately reflect that the step runs `npm publish --dry-run`.

## Tested scenarios
- Workflow_dispatch with `dry-run=true`: now correctly skips publish and runs dry-run step
- Workflow_dispatch with `dry-run=false`: correctly runs publish step
- Release event trigger: `inputs.dry-run` is absent; `|| 'false'` fallback ensures publish runs

## Fixed issue
Fixes the failure observed in run [#173](https://github.com/Adyen/adyen-node-api-library/actions/runs/27683305545/job/81876064164)