### PR TITLE
feat: export NexoCrypto from package index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ export { default as HttpURLConnectionClient } from "./httpClient/httpURLConnecti
 // Export a custom exception for HTTP client errors
 export { default as HttpClientException } from "./httpClient/httpClientException";
 
+// Export NexoCrypto for local terminal API security
+export { default as NexoCrypto } from "./security/nexoCrypto";
+
 // Export all the typings under the `Types` namespace
 export * as Types from "./typings";
+
 


### PR DESCRIPTION
### Description
This PR addresses issue #1447 by exporting the `NexoCrypto` class from the main library entry point (`src/index.ts`).

Previously, `NexoCrypto` was not exported from the main entry point, forcing developers to import it via deep internal paths like `@adyen/api-library/lib/src/security/nexoCrypto`. Since the library compiles to CommonJS, this deep path resolution under ESM-based runtimes returned the default wrapper object `{ default: [class NexoCrypto] }` instead of the class constructor itself, causing runtime `TypeError: NexoCrypto is not a constructor` unless developers manually appended `.default`. 

By exporting it as a named export from the main index file, both ESM and CommonJS developers can cleanly import `NexoCrypto` directly from the package root:
`import { NexoCrypto } from '@adyen/api-library';`

### Approach
Added `export { default as NexoCrypto } from "./security/nexoCrypto";` to `src/index.ts`.

### Testing
- Ran build successfully with `npm run build`.
- Ran the entire test suite (`npm test`) and verified that all 532 tests pass.
