### PR TITLE
fix: remove environment from publish-npm job to fix OIDC trusted publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -40,7 +40,6 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: build
-    environment: release
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Description
The `publish-npm` job had `environment: release` set, which causes GitHub Actions to include an `environment: "release"` claim in the OIDC token. The npm trusted publishing configuration for `@adyen/api-library` does not expect this claim, so npm rejects the publish request with a 404 error.

## Fix
Removed `environment: release` from the `publish-npm` job, aligning with how `adyen-web` publishes successfully.

## Tested scenarios
- Dry-run workflow already passes
- Real publish was failing with `npm error 404 Not Found - PUT https://registry.npmjs.org/@adyen%2fapi-library`

## Fixed issue
Fixes the failed v31.0.0 publish run: https://github.com/Adyen/adyen-node-api-library/actions/runs/28023489519