### PR TITLE
revert: restore environment: release in publish-npm job

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -40,6 +40,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: build
+    environment: release
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
Reverts commit 9cdc3aefce3498d7a238abe87090a54a5ba542b5 (PR #1705).

Restores `environment: release` on the `publish-npm` job. This configuration is needed to match the npm trusted publishing configuration for `@adyen/api-library` on NPMJS.