### PR TITLE
fix: guard against mismatched HMAC length in NexoCrypto.validateHmac (#1703)

### DIFF
--- a/src/__tests__/nexoCrypto.spec.ts
+++ b/src/__tests__/nexoCrypto.spec.ts
@@ -73,6 +73,24 @@ describe("NexoCrypto", (): void => {
         expect(() => nexoCrypto.decrypt(tampered, securityKey)).toThrow("Hmac validation failed");
     });
 
+    test("decrypt throws NexoCryptoException on a different-length HMAC", (): void => {
+        const nexoCrypto = new NexoCrypto();
+        const payload = JSON.stringify({ test: "data" });
+
+        const encrypted = NexoCrypto.encrypt(messageHeader, payload, securityKey);
+        // Truncate the HMAC so its length differs from the computed one. Without a
+        // length guard, crypto.timingSafeEqual throws a raw TypeError instead of the
+        // expected NexoCryptoException. See #1703.
+        const truncatedHmac = Buffer.from(encrypted.SecurityTrailer.Hmac, "base64").subarray(0, 16);
+        const tampered: SaleToPOISecuredMessage = {
+            ...encrypted,
+            SecurityTrailer: { ...encrypted.SecurityTrailer, Hmac: truncatedHmac.toString("base64") },
+        };
+
+        expect(() => nexoCrypto.decrypt(tampered, securityKey)).toThrow(NexoCryptoException);
+        expect(() => nexoCrypto.decrypt(tampered, securityKey)).toThrow("Hmac validation failed");
+    });
+
     test("decrypt throws InvalidSecurityKeyException when Passphrase is missing", (): void => {
         const nexoCrypto = new NexoCrypto();
         const payload = JSON.stringify({ test: "data" });

--- a/src/security/nexoCrypto.ts
+++ b/src/security/nexoCrypto.ts
@@ -115,7 +115,10 @@ class NexoCrypto {
     private validateHmac(receivedHmac: Buffer, decryptedMessage: Buffer, derivedKey: NexoDerivedKey): void {
         const hmac = NexoCrypto.hmac(decryptedMessage, derivedKey);
 
-        if (!timingSafeEqual(hmac, receivedHmac)) {
+        // timingSafeEqual throws a raw TypeError when the buffers differ in
+        // length, so guard on length first: a length mismatch is simply an
+        // invalid HMAC and must raise NexoCryptoException like any other failure.
+        if (hmac.length !== receivedHmac.length || !timingSafeEqual(hmac, receivedHmac)) {
             throw new NexoCryptoException("Hmac validation failed");
         }
     }


### PR DESCRIPTION
Fixes #1703

## What was wrong

`validateHmac` in `src/security/nexoCrypto.ts` called `crypto.timingSafeEqual(hmac, receivedHmac)` without first checking the buffers are the same length. Node's `timingSafeEqual` throws a raw `TypeError: Input buffers must have the same length` when they differ, so a tampered message with a truncated or malformed HMAC produced an unhandled `TypeError` instead of the expected `NexoCryptoException`.

## Fix

Add a length guard before `timingSafeEqual`, as suggested in the issue — a length mismatch is simply an invalid HMAC:

```ts
if (hmac.length !== receivedHmac.length || !timingSafeEqual(hmac, receivedHmac)) {
    throw new NexoCryptoException("Hmac validation failed");
}
```

## Test

Adds a regression test that truncates the HMAC to a different length and asserts `decrypt` throws `NexoCryptoException` rather than a raw `TypeError`. Verified it fails on `main` with the `TypeError` and passes with this change; the full NexoCrypto suite and `tsc` build are green.

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening.*