### PR TITLE
Add cloud device live URL support with region-based routing

### DIFF
--- a/src/__tests__/cloudDeviceApi.spec.ts
+++ b/src/__tests__/cloudDeviceApi.spec.ts
@@ -20,6 +20,8 @@
 import nock from "nock";
 import { createClient } from "../__mocks__/base";
 import Client from "../client";
+import Config, { EnvironmentEnum, RegionEnum } from "../config";
+import { CloudDeviceApi } from "../services/clouddevice/cloudDeviceApi";
 import { CloudDeviceAPI } from "../services";
 import { CloudDeviceApiRequest } from "../typings/clouddevice/models";
 import { DeviceStatus } from "../typings/clouddevice/models";
@@ -83,6 +85,34 @@ beforeEach((): void => {
 
 afterEach(() => {
     nock.cleanAll();
+});
+
+describe("CloudDeviceApi baseUrl", (): void => {
+    const getBaseUrl = (api: CloudDeviceApi): string => (api as unknown as { baseUrl: string }).baseUrl;
+
+    test("should build TEST baseUrl", (): void => {
+        const testClient = new Client(new Config({ apiKey: "test", environment: EnvironmentEnum.TEST }));
+        const api = new CloudDeviceApi(testClient);
+        expect(getBaseUrl(api)).toBe("https://device-api-test.adyen.com/v1");
+    });
+
+    test("should build LIVE baseUrl without region", (): void => {
+        const liveClient = new Client(new Config({ apiKey: "test", environment: EnvironmentEnum.LIVE }));
+        const api = new CloudDeviceApi(liveClient);
+        expect(getBaseUrl(api)).toBe("https://device-api-live.adyen.com/v1");
+    });
+
+    test("should build LIVE baseUrl with EU region", (): void => {
+        const liveClient = new Client(new Config({ apiKey: "test", environment: EnvironmentEnum.LIVE, region: RegionEnum.EU }));
+        const api = new CloudDeviceApi(liveClient);
+        expect(getBaseUrl(api)).toBe("https://device-api-live.adyen.com/v1");
+    });
+
+    test("should build LIVE baseUrl with US region", (): void => {
+        const liveClient = new Client(new Config({ apiKey: "test", environment: EnvironmentEnum.LIVE, region: RegionEnum.US }));
+        const api = new CloudDeviceApi(liveClient);
+        expect(getBaseUrl(api)).toBe("https://device-api-live-us.adyen.com/v1");
+    });
 });
 
 describe("CloudDeviceApi", (): void => {

--- a/src/__tests__/service.spec.ts
+++ b/src/__tests__/service.spec.ts
@@ -501,5 +501,18 @@ describe("Service", () => {
         expect(service.testCreateBaseUrl(url)).toBe("https://device-api-live-apse.adyen.com/v1");
     });
 
+    it("should fall back to generic replacement for custom device-api domains", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.LIVE,
+            region: RegionEnum.US
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://my-proxy-test.example.com/device-api-v1/path";
+        expect(service.testCreateBaseUrl(url)).toBe("https://my-proxy-live.example.com/device-api-v1/path");
+    });
+
 
 });  

--- a/src/__tests__/service.spec.ts
+++ b/src/__tests__/service.spec.ts
@@ -1,6 +1,6 @@
 import Service from "../service";
 import Client from "../client";
-import Config, { EnvironmentEnum } from "../config";
+import Config, { EnvironmentEnum, RegionEnum } from "../config";
 
 class TestService extends Service {
     public constructor(client: Client) {
@@ -422,6 +422,83 @@ describe("Service", () => {
         const service = new TestService(client);
         const url = "https://obgateway-test.adyen.com/obgateway/v1";
         expect(service.testCreateBaseUrl(url)).toBe("https://obgateway-live.adyen.com/obgateway/v1");
+    });
+
+    // Cloud Device API
+    it("should keep TEST url for Cloud Device API", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.TEST
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://device-api-test.adyen.com/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://device-api-test.adyen.com/v1");
+    });
+
+    it("should build LIVE url for Cloud Device API without region", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.LIVE
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://device-api-test.adyen.com/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://device-api-live.adyen.com/v1");
+    });
+
+    it("should build LIVE url for Cloud Device API with EU region", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.LIVE,
+            region: RegionEnum.EU
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://device-api-test.adyen.com/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://device-api-live.adyen.com/v1");
+    });
+
+    it("should build LIVE url for Cloud Device API with AU region", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.LIVE,
+            region: RegionEnum.AU
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://device-api-test.adyen.com/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://device-api-live-au.adyen.com/v1");
+    });
+
+    it("should build LIVE url for Cloud Device API with US region", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.LIVE,
+            region: RegionEnum.US
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://device-api-test.adyen.com/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://device-api-live-us.adyen.com/v1");
+    });
+
+    it("should build LIVE url for Cloud Device API with APSE region", () => {
+        const config = new Config({
+            apiKey: "test_key",
+            environment: EnvironmentEnum.LIVE,
+            region: RegionEnum.APSE
+        });
+        client = new Client(config);
+
+        const service = new TestService(client);
+        const url = "https://device-api-test.adyen.com/v1";
+        expect(service.testCreateBaseUrl(url)).toBe("https://device-api-live-apse.adyen.com/v1");
     });
 
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -18,7 +18,7 @@
  */
 
 import Client from "./client";
-import Config, { EnvironmentEnum } from "./config";
+import Config, { EnvironmentEnum, RegionEnum } from "./config";
 
 /**
  * Base Service class for all API services.
@@ -79,6 +79,14 @@ class Service {
 
             return url.replace("https://checkout-test.adyen.com/",
                     `https://${this.client.config.liveEndpointUrlPrefix}-checkout-live.adyenpayments.com/checkout/`);
+        }
+
+        if (url.includes("device-api-")) {
+            if (!config.region || config.region === RegionEnum.EU) {
+                return url.replace("https://device-api-test.adyen.com", "https://device-api-live.adyen.com");
+            }
+            return url.replace("https://device-api-test.adyen.com",
+                    `https://device-api-live-${config.region.toLowerCase()}.adyen.com`);
         }
 
         return url.replace("-test", "-live");

--- a/src/service.ts
+++ b/src/service.ts
@@ -81,7 +81,7 @@ class Service {
                     `https://${this.client.config.liveEndpointUrlPrefix}-checkout-live.adyenpayments.com/checkout/`);
         }
 
-        if (url.includes("device-api-")) {
+        if (url.includes("https://device-api-test.adyen.com")) {
             if (!config.region || config.region === RegionEnum.EU) {
                 return url.replace("https://device-api-test.adyen.com", "https://device-api-live.adyen.com");
             }


### PR DESCRIPTION
## Description
Add region-aware live URL construction for the Cloud Device API in `Service.createBaseUrl`. When the environment is LIVE and the URL contains `device-api-`, the method now routes to the correct regional endpoint:

- No region or EU: `https://device-api-live.adyen.com`
- AU: `https://device-api-live-au.adyen.com`
- US: `https://device-api-live-us.adyen.com`
- APSE: `https://device-api-live-apse.adyen.com`

This mirrors the logic in the Java library (`Service.java`).

## Tested scenarios
- `service.spec.ts`: 6 new tests covering TEST passthrough and all region variants (no region, EU, AU, US, APSE)
- `cloudDeviceApi.spec.ts`: 4 new baseUrl tests covering TEST, LIVE without region, LIVE with EU region, LIVE with US region

## Fixed issue
N/A