### PR TITLE
fix: guard HMAC comparison on decoded length in HmacValidator

### DIFF
--- a/src/__tests__/hmacValidator.spec.ts
+++ b/src/__tests__/hmacValidator.spec.ts
@@ -155,4 +155,31 @@ describe("HMAC Validator", function (): void {
         expect(hmacValidator.validateHMACSignature(key, malformedSignature, data)).toBe(false);
     });
 
+    it("validateHMAC returns false (not throw) when the item signature length matches but decodes to a different byte length", function (): void {
+        // 44 base64 chars, same length as a real SHA-256 HMAC signature, but decodes to 33 bytes.
+        const malformedSignature = "A".repeat(44);
+        const item = {
+            ...notification.notificationItems![0],
+            additionalData: { [ApiConstants.HMAC_SIGNATURE]: malformedSignature }
+        };
+        expect((): boolean => hmacValidator.validateHMAC(item, key)).not.toThrow();
+        expect(hmacValidator.validateHMAC(item, key)).toBe(false);
+    });
+
+    it("validateBankingHMAC returns false (not throw) when the signature length matches but decodes to a different byte length", function (): void {
+        const hmacKey = "11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB";
+        const data = readFileSync("./src/__mocks__/notification/accountHolderCreated.json", "utf8");
+        // 44 base64 chars, same length as a real SHA-256 HMAC signature, but decodes to 33 bytes.
+        const malformedSignature = "A".repeat(44);
+        expect((): boolean => hmacValidator.validateBankingHMAC(malformedSignature, hmacKey, data)).not.toThrow();
+        expect(hmacValidator.validateBankingHMAC(malformedSignature, hmacKey, data)).toBe(false);
+    });
+
+    it("returns false when the received signature is empty or undefined (secureCompare guard)", function (): void {
+        const hmacKey = "11223344D785FBAE710E7F943F307971BB61B21281C98C9129B3D4018A57B2EB";
+        const data = readFileSync("./src/__mocks__/notification/accountHolderCreated.json", "utf8");
+        expect(hmacValidator.validateHMACSignature(hmacKey, "", data)).toBe(false);
+        expect(hmacValidator.validateHMACSignature(hmacKey, undefined as unknown as string, data)).toBe(false);
+    });
+
 });

--- a/src/__tests__/hmacValidator.spec.ts
+++ b/src/__tests__/hmacValidator.spec.ts
@@ -145,4 +145,14 @@ describe("HMAC Validator", function (): void {
         expect(isValid).toBeTruthy;
     });
 
+
+    it("should return false (not throw) when the signature length matches but decodes to a different byte length", function (): void {
+        const key = "DFB1EB5485295588A7DED4CF1BB4CA24C2B41BFC33C5EA6CA05B2A87F98F1F55";
+        const data = "pspReference:originalReference:merchantAccount:reference:1000:EUR:AUTHORISATION:true";
+        // 44 base64 chars, same length as a real SHA-256 HMAC signature, but decodes to 33 bytes.
+        const malformedSignature = "A".repeat(44);
+        expect((): boolean => hmacValidator.validateHMACSignature(key, malformedSignature, data)).not.toThrow();
+        expect(hmacValidator.validateHMACSignature(key, malformedSignature, data)).toBe(false);
+    });
+
 });

--- a/src/utils/hmacValidator.ts
+++ b/src/utils/hmacValidator.ts
@@ -48,13 +48,7 @@ class HmacValidator {
      */
     public validateBankingHMAC(hmacKey: string, hmacSign: string, notification: string): boolean {
         const expectedSign = createHmac(HmacValidator.HMAC_SHA256_ALGORITHM, Buffer.from(hmacSign, "hex")).update(notification, "utf8").digest("base64");
-        if(hmacKey?.length === expectedSign.length) {
-            return timingSafeEqual(
-                Buffer.from(expectedSign, "base64"),
-                Buffer.from(hmacKey, "base64")
-            );
-        }
-        return false;
+        return HmacValidator.secureCompare(expectedSign, hmacKey);
     }
 
     /**
@@ -66,13 +60,7 @@ class HmacValidator {
      */
     public validateHMACSignature(hmacKey: string, hmacSignature: string, data: string): boolean {
         const expectedSign = createHmac(HmacValidator.HMAC_SHA256_ALGORITHM, Buffer.from(hmacKey, "hex")).update(data, "utf8").digest("base64");
-        if(hmacSignature?.length === expectedSign.length) {
-            return timingSafeEqual(
-                Buffer.from(expectedSign, "base64"),
-                Buffer.from(hmacSignature, "base64")
-            );
-        }
-        return false;
+        return HmacValidator.secureCompare(expectedSign, hmacSignature);
     }
 
     /**
@@ -85,13 +73,7 @@ class HmacValidator {
         if (notificationRequestItem.additionalData?.[ApiConstants.HMAC_SIGNATURE]) {
             const expectedSign = this.calculateHmac(notificationRequestItem, key);
             const merchantSign = notificationRequestItem.additionalData?.[ApiConstants.HMAC_SIGNATURE];
-            if(merchantSign?.length === expectedSign.length) {
-                return timingSafeEqual(
-                    Buffer.from(expectedSign, "base64"),
-                    Buffer.from(merchantSign, "base64")
-                );
-            }
-            return false;
+            return HmacValidator.secureCompare(expectedSign, merchantSign);
         }
         throw Error(`Missing ${ApiConstants.HMAC_SIGNATURE}`);
     }
@@ -134,6 +116,21 @@ class HmacValidator {
     public calculateHmacSignature(data: string, key: string): string {
         const rawKey = Buffer.from(key, "hex");
         return createHmac(HmacValidator.HMAC_SHA256_ALGORITHM, rawKey).update(data, "utf8").digest("base64");
+    }
+
+    /**
+     * Constant-time comparison of two base64-encoded signatures. Guards on the
+     * decoded buffer length first: timingSafeEqual throws a TypeError when the
+     * buffers differ in length, and two base64 strings of equal character
+     * length can still decode to different byte lengths.
+     */
+    private static secureCompare(expected: string, received: string | undefined): boolean {
+        if (!received) {
+            return false;
+        }
+        const expectedBuffer = Buffer.from(expected, "base64");
+        const receivedBuffer = Buffer.from(received, "base64");
+        return expectedBuffer.length === receivedBuffer.length && timingSafeEqual(expectedBuffer, receivedBuffer);
     }
     
 }


### PR DESCRIPTION
### Problem
The webhook validators (`validateHMAC`, `validateHMACSignature`, `validateBankingHMAC`) compared the base64 **string** length before calling `timingSafeEqual`, but `timingSafeEqual` requires equal **decoded buffer** length. Two base64 strings of equal character length can decode to different byte lengths — e.g. a 44-char *unpadded* signature decodes to 33 bytes while a real SHA-256 HMAC decodes to 32. A crafted signature of matching string length therefore made `timingSafeEqual` throw an unhandled `TypeError` instead of the validator returning `false`.

### Fix
Add a shared constant-time `secureCompare` that decodes both signatures and guards on the **decoded buffer length** before `timingSafeEqual`, and use it in all three validators. Mirrors the earlier NexoCrypto length-guard fix (#1703).

### Test
Added a regression test: a signature whose base64 length matches but decodes to a different byte length now returns `false` without throwing.
