### PR TITLE
Add PredefinedContentHelper for Cloud device API (tapi)

### DIFF
--- a/doc/CloudDeviceApi.md
+++ b/doc/CloudDeviceApi.md
@@ -160,3 +160,33 @@ const payload = "...";
 const decryptedPayload = encryptedCloudDeviceApi.decryptNotification(payload);
 console.log(decryptedPayload);
 ```
+
+## Helper classes
+
+### PredefinedContentHelper
+
+When your integration receives a Display event notification, the terminal sends a `DisplayRequest` with an `OutputContent` that contains a `PredefinedContent.ReferenceID`. This field is a query-string that encodes the event type and transaction context.
+
+`PredefinedContentHelper` parses the `ReferenceID` and exposes typed accessors so you don't have to hand-roll query-string parsing.
+
+``` typescript
+import { Types } from "@adyen/api-library";
+
+const { PredefinedContentHelper, DisplayNotificationEvent } = Types.tapi;
+
+// referenceId comes from DisplayRequest.OutputContent.PredefinedContent.ReferenceID
+const referenceId = "TransactionID=oLkO001517998574000&TimeStamp=2018-02-07T10%3a16%3a14.000Z&event=PIN_ENTERED";
+
+const helper = new PredefinedContentHelper(referenceId);
+
+const event = helper.getEvent(); // DisplayNotificationEvent.PIN_ENTERED or null
+if (event === DisplayNotificationEvent.PIN_ENTERED) {
+    console.log("Customer is entering PIN");
+}
+
+console.log(helper.getTransactionId()); // "oLkO001517998574000"
+console.log(helper.getTimeStamp());     // "2018-02-07T10:16:14.000Z"
+console.log(helper.toObject());         // { TransactionID: "...", TimeStamp: "...", event: "PIN_ENTERED" }
+```
+
+The `DisplayNotificationEvent` enum contains all supported event values, such as `CARD_INSERTED`, `WAIT_FOR_PIN`, `PIN_ENTERED`, `TENDER_FINAL`, and others.

--- a/src/__tests__/tapiPredefinedContentHelper.spec.ts
+++ b/src/__tests__/tapiPredefinedContentHelper.spec.ts
@@ -1,0 +1,51 @@
+import { PredefinedContentHelper, DisplayNotificationEvent } from "../typings/tapi/predefinedContentHelper";
+
+describe("tapi PredefinedContentHelper", () => {
+    it("should extract a valid event", () => {
+        const ReferenceID = "TransactionID=oLkO001517998574000&TimeStamp=2018-02-07T10%3a16%3a14.000Z&event=PIN_ENTERED";
+        const helper = new PredefinedContentHelper(ReferenceID);
+        expect(helper.getEvent()).toBe(DisplayNotificationEvent.PIN_ENTERED);
+    });
+
+    it("should return null for an invalid event", () => {
+        const helper = new PredefinedContentHelper("event=INVALID_EVENT");
+        expect(helper.getEvent()).toBeNull();
+    });
+
+    it("should extract TransactionID", () => {
+        const helper = new PredefinedContentHelper("TransactionID=12345&TimeStamp=2018-02-07T10%3a16%3a14.000Z&event=PIN_ENTERED");
+        expect(helper.getTransactionId()).toBe("12345");
+    });
+
+    it("should extract TimeStamp", () => {
+        const helper = new PredefinedContentHelper("TimeStamp=2024-07-11T12:00:00Z");
+        expect(helper.getTimeStamp()).toBe("2024-07-11T12:00:00Z");
+    });
+
+    it("should extract arbitrary key", () => {
+        const helper = new PredefinedContentHelper("foo=bar&baz=qux");
+        expect(helper.get("foo")).toBe("bar");
+        expect(helper.get("baz")).toBe("qux");
+        expect(helper.get("missing")).toBeNull();
+    });
+
+    it("should convert params to object", () => {
+        const helper = new PredefinedContentHelper("a=1&b=2&event=WAIT_FOR_PIN");
+        expect(helper.toObject()).toEqual({ a: "1", b: "2", event: "WAIT_FOR_PIN" });
+    });
+
+    it("should handle empty, null, or undefined referenceId", () => {
+        const helpers = [
+            new PredefinedContentHelper(""),
+            new PredefinedContentHelper(null),
+            new PredefinedContentHelper(undefined),
+            new PredefinedContentHelper(),
+        ];
+        for (const helper of helpers) {
+            expect(helper.getEvent()).toBeNull();
+            expect(helper.getTransactionId()).toBeNull();
+            expect(helper.getTimeStamp()).toBeNull();
+            expect(helper.toObject()).toEqual({});
+        }
+    });
+});

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -25,6 +25,7 @@ export * as platformsFund from "./platformsFund/models";
 export * as platformsHostedOnboardingPage from "./platformsHostedOnboardingPage/models";
 export * as recurring from "./recurring/models";
 export * as storedValue from "./storedValue/models";
+export * as tapi from "./tapi/models";
 export * as terminal from "./terminal/models";
 export * as terminalManagement from "./terminalManagement/models";
 export * as transfers from "./transfers/models";

--- a/src/typings/tapi/models.ts
+++ b/src/typings/tapi/models.ts
@@ -156,3 +156,6 @@ export * from "./uTMCoordinates"
 
 // serializing and deserializing typed objects 
 export * from "./objectSerializer"
+
+// helpers
+export * from "./predefinedContentHelper"

--- a/src/typings/tapi/predefinedContentHelper.ts
+++ b/src/typings/tapi/predefinedContentHelper.ts
@@ -1,0 +1,76 @@
+/**
+ * PredefinedContentHelper class to parse and manage predefined content reference IDs
+ * for the Cloud device API (tapi models).
+ */
+export class PredefinedContentHelper {
+    private params: URLSearchParams;
+
+    constructor(referenceId?: string | null) {
+        this.params = new URLSearchParams(referenceId ?? "");
+    }
+
+    /**
+     * Extracts and validates the `event` value from the ReferenceID.
+     *
+     * @returns A valid `DisplayNotificationEvent`, otherwise `null`.
+     *
+     * @example
+     * const helper = new PredefinedContentHelper("...&event=PIN_ENTERED");
+     * const event = helper.getEvent(); // DisplayNotificationEvent.PIN_ENTERED or null
+     */
+    getEvent(): DisplayNotificationEvent | null {
+        const event = this.params.get("event");
+
+        if (event && Object.values(DisplayNotificationEvent).includes(event as DisplayNotificationEvent)) {
+            return event as DisplayNotificationEvent;
+        }
+        return null;
+    }
+
+    getTransactionId(): string | null {
+        return this.params.get("TransactionID");
+    }
+
+    getTimeStamp(): string | null {
+        return this.params.get("TimeStamp");
+    }
+
+    get(key: string): string | null {
+        return this.params.get(key);
+    }
+
+    toObject(): Record<string, string> {
+        return Object.fromEntries(this.params);
+    }
+}
+
+// Supported events for display notifications
+// See https://docs.adyen.com/point-of-sale/design-your-integration/notifications/display-notifications#display-notification-types
+export enum DisplayNotificationEvent {
+    TENDER_CREATED = "TENDER_CREATED",
+    CARD_INSERTED = "CARD_INSERTED",
+    CARD_PRESENTED = "CARD_PRESENTED",
+    CARD_SWIPED = "CARD_SWIPED",
+    WAIT_FOR_APP_SELECTION = "WAIT_FOR_APP_SELECTION",
+    APPLICATION_SELECTED = "APPLICATION_SELECTED",
+    ASK_SIGNATURE = "ASK_SIGNATURE",
+    CHECK_SIGNATURE = "CHECK_SIGNATURE",
+    SIGNATURE_CHECKED = "SIGNATURE_CHECKED",
+    WAIT_FOR_PIN = "WAIT_FOR_PIN",
+    PIN_ENTERED = "PIN_ENTERED",
+    PRINT_RECEIPT = "PRINT_RECEIPT",
+    RECEIPT_PRINTED = "RECEIPT_PRINTED",
+    CARD_REMOVED = "CARD_REMOVED",
+    TENDER_FINAL = "TENDER_FINAL",
+    ASK_DCC = "ASK_DCC",
+    DCC_ACCEPTED = "DCC_ACCEPTED",
+    DCC_REJECTED = "DCC_REJECTED",
+    ASK_GRATUITY = "ASK_GRATUITY",
+    GRATUITY_ENTERED = "GRATUITY_ENTERED",
+    BALANCE_QUERY_STARTED = "BALANCE_QUERY_STARTED",
+    BALANCE_QUERY_COMPLETED = "BALANCE_QUERY_COMPLETED",
+    LOAD_STARTED = "LOAD_STARTED",
+    LOAD_COMPLETED = "LOAD_COMPLETED",
+    PROVIDE_CARD_DETAILS = "PROVIDE_CARD_DETAILS",
+    CARD_DETAILS_PROVIDED = "CARD_DETAILS_PROVIDED",
+}


### PR DESCRIPTION
## Context

Closes #1720.

The Cloud device API uses `tapi` models, but the existing `PredefinedContentHelper` only lives in the legacy `terminal` package. This PR adds an equivalent helper to the `tapi` package, matching the Java library's `com.adyen.util.tapi.PredefinedContentHelper`.

## Changes

- **`src/typings/tapi/predefinedContentHelper.ts`** — new `PredefinedContentHelper` class and `DisplayNotificationEvent` enum for the `tapi` package
- **`src/typings/tapi/models.ts`** — exports the new helper under the `// helpers` section
- **`src/typings/index.ts`** — exports `tapi` as a named namespace (`Types.tapi.*`), so consumers no longer need deep import paths
- **`src/__tests__/tapiPredefinedContentHelper.spec.ts`** — full test coverage mirroring the terminal helper tests
- **`doc/CloudDeviceApi.md`** — new "Helper classes" section documenting `PredefinedContentHelper` usage

## Usage

```typescript
import { Types } from "@adyen/api-library";

const { PredefinedContentHelper, DisplayNotificationEvent } = Types.tapi;

const helper = new PredefinedContentHelper(referenceId);
const event = helper.getEvent(); // DisplayNotificationEvent.PIN_ENTERED or null
```