### PR TITLE
Add SaleToAcquirerData parser and SaleDataHelper for Cloud device API (tapi)

### DIFF
--- a/doc/CloudDeviceApi.md
+++ b/doc/CloudDeviceApi.md
@@ -170,9 +170,7 @@ When your integration receives a Display event notification, the terminal sends 
 `PredefinedContentHelper` parses the `ReferenceID` and exposes typed accessors so you don't have to hand-roll query-string parsing.
 
 ``` typescript
-import { Types } from "@adyen/api-library";
-
-const { PredefinedContentHelper, DisplayNotificationEvent } = Types.tapi;
+import { PredefinedContentHelper, DisplayNotificationEvent } from "@adyen/api-library";
 
 // referenceId comes from DisplayRequest.OutputContent.PredefinedContent.ReferenceID
 const referenceId = "TransactionID=oLkO001517998574000&TimeStamp=2018-02-07T10%3a16%3a14.000Z&event=PIN_ENTERED";
@@ -190,3 +188,45 @@ console.log(helper.toObject());         // { TransactionID: "...", TimeStamp: ".
 ```
 
 The `DisplayNotificationEvent` enum contains all supported event values, such as `CARD_INSERTED`, `WAIT_FOR_PIN`, `PIN_ENTERED`, `TENDER_FINAL`, and others.
+
+### SaleDataHelper
+
+The `SaleData.SaleToAcquirerData` field carries sale information intended for the acquirer, encoded either as Base64 JSON or as form-encoded key-value pairs. `SaleDataHelper` wraps a `SaleData` object, auto-detects the format, and decodes it into a typed `SaleToAcquirerData` object.
+
+``` typescript
+import { SaleDataHelper, Types } from "@adyen/api-library";
+
+const saleData = new Types.tapi.SaleData();
+saleData.SaleToAcquirerData = "shopperEmail=foo@bar.com&currency=EUR&metadata.orderId=42";
+
+// returns the parsed SaleToAcquirerData, or null if the field is absent or unparsable
+const acquirerData = new SaleDataHelper(saleData).getSaleToAcquirerData();
+console.log(acquirerData);
+// {
+//   shopperEmail: "foo@bar.com",
+//   currency: "EUR",
+//   metadata: { orderId: "42" }
+// }
+```
+
+### SaleToAcquirerDataParser
+
+Use `SaleToAcquirerDataParser` directly when you have the raw string, or when you want to build and encode a `SaleToAcquirerData` payload yourself. It exposes `parse` (auto-detects the format), the explicit `fromBase64` / `fromKeyValuePairs` decoders, and the `toJson` / `toBase64` serializers.
+
+``` typescript
+import { SaleToAcquirerDataParser, SaleToAcquirerData, RecurringProcessingModel } from "@adyen/api-library";
+
+// Parse a raw value, auto-detecting Base64 JSON vs key-value pairs
+const parsed = SaleToAcquirerDataParser.parse("shopperEmail=foo@bar.com&tenderOption=AskGratuity");
+
+// Build a payload and encode it for SaleData.SaleToAcquirerData
+const data: SaleToAcquirerData = {
+    merchantAccount: "TestMerchant",
+    currency: "EUR",
+    shopperReference: "shopper-123",
+    recurringProcessingModel: RecurringProcessingModel.CardOnFile,
+    metadata: { orderId: "42" },
+};
+
+const encoded = SaleToAcquirerDataParser.toBase64(data); // Base64 string, ready to assign to SaleData.SaleToAcquirerData
+```

--- a/doc/CloudDeviceApi.md
+++ b/doc/CloudDeviceApi.md
@@ -189,6 +189,12 @@ console.log(helper.toObject());         // { TransactionID: "...", TimeStamp: ".
 
 The `DisplayNotificationEvent` enum contains all supported event values, such as `CARD_INSERTED`, `WAIT_FOR_PIN`, `PIN_ENTERED`, `TENDER_FINAL`, and others.
 
+### Working with SaleToAcquirerData
+
+`SaleToAcquirerData` is a field you add to the `SaleData` of your Cloud device API `PaymentRequest` to send extra information to the acquirer, such as shopper details, recurring/tokenization settings, tender options, and custom `metadata`. See [Add information to a payment](https://docs.adyen.com/point-of-sale/add-data). On the wire it is a single string, encoded either as Base64 JSON or as form-encoded key-value pairs.
+
+Use `SaleToAcquirerDataParser.toBase64(...)` to **build and encode** it into an outgoing request. Use `SaleDataHelper` / `SaleToAcquirerDataParser.parse(...)` to **decode** a `SaleData.SaleToAcquirerData` string you already hold (for example when inspecting, logging, or forwarding a request).
+
 ### SaleDataHelper
 
 The `SaleData.SaleToAcquirerData` field carries sale information intended for the acquirer, encoded either as Base64 JSON or as form-encoded key-value pairs. `SaleDataHelper` wraps a `SaleData` object, auto-detects the format, and decodes it into a typed `SaleToAcquirerData` object.

--- a/src/__tests__/utils/tapi/saleToAcquirerData.spec.ts
+++ b/src/__tests__/utils/tapi/saleToAcquirerData.spec.ts
@@ -93,6 +93,23 @@ describe("tapi SaleToAcquirerDataParser", () => {
         expect(result.recurringProcessingModel).toBeUndefined();
     });
 
+    it("fromKeyValuePairs should ignore empty keys and empty metadata sub-keys", () => {
+        const raw = "=orphan&shopperEmail=foo@bar.com&metadata.=noKey&metadata.orderId=42";
+        const result = SaleToAcquirerDataParser.fromKeyValuePairs(raw);
+        expect(result).toEqual({
+            shopperEmail: "foo@bar.com",
+            metadata: { orderId: "42" },
+        });
+        expect(result.additionalData).toBeUndefined();
+    });
+
+    it("parse should detect Base64 JSON that contains whitespace/newlines", () => {
+        const base64 = SaleToAcquirerDataParser.toBase64(sample);
+        // Simulate MIME-style line wrapping / stray whitespace in the payload.
+        const wrapped = base64.replace(/(.{8})/g, "$1\n");
+        expect(SaleToAcquirerDataParser.parse(wrapped)).toEqual(sample);
+    });
+
     it("toJson and toBase64 should round-trip", () => {
         const json = SaleToAcquirerDataParser.toJson(sample);
         expect(JSON.parse(json)).toEqual(sample);

--- a/src/__tests__/utils/tapi/saleToAcquirerData.spec.ts
+++ b/src/__tests__/utils/tapi/saleToAcquirerData.spec.ts
@@ -1,0 +1,136 @@
+import { SaleData } from "../../../typings/tapi/saleData";
+import { RecurringProcessingModel, SaleToAcquirerData } from "../../../utils/tapi/saleToAcquirerData";
+import { SaleDataHelper } from "../../../utils/tapi/saleDataHelper";
+import * as SaleToAcquirerDataParser from "../../../utils/tapi/saleToAcquirerDataParser";
+
+describe("tapi SaleToAcquirerDataParser", () => {
+    const sample: SaleToAcquirerData = {
+        shopperEmail: "foo@bar.com",
+        shopperReference: "shopper-123",
+        currency: "EUR",
+        recurringProcessingModel: RecurringProcessingModel.CardOnFile,
+        metadata: { orderId: "42" },
+    };
+
+    it("fromBase64 should decode a Base64-encoded JSON object", () => {
+        const base64 = Buffer.from(JSON.stringify(sample), "utf8").toString("base64");
+        expect(SaleToAcquirerDataParser.fromBase64(base64)).toEqual(sample);
+    });
+
+    it("fromBase64 should throw on invalid input", () => {
+        const invalid = Buffer.from("not json", "utf8").toString("base64");
+        expect(() => SaleToAcquirerDataParser.fromBase64(invalid)).toThrow();
+    });
+
+    it("parse should auto-detect Base64-encoded JSON", () => {
+        const base64 = SaleToAcquirerDataParser.toBase64(sample);
+        expect(SaleToAcquirerDataParser.parse(base64)).toEqual(sample);
+    });
+
+    it("parse should auto-detect key-value pairs", () => {
+        const raw = "shopperEmail=foo@bar.com&currency=EUR&tenderOption=AskGratuity";
+        expect(SaleToAcquirerDataParser.parse(raw)).toEqual({
+            shopperEmail: "foo@bar.com",
+            currency: "EUR",
+            tenderOption: "AskGratuity",
+        });
+    });
+
+    it("fromKeyValuePairs should map all known fields", () => {
+        const raw = [
+            "shopperEmail=foo@bar.com",
+            "shopperReference=ref-1",
+            "shopperStatement=statement",
+            "recurringContract=RECURRING",
+            "recurringDetailName=detail",
+            "recurringTokenService=service",
+            "recurringProcessingModel=Subscription",
+            "store=store-1",
+            "merchantAccount=TestMerchant",
+            "currency=USD",
+            "tenderOption=AskGratuity",
+            "authorisationType=PreAuth",
+            "ssc=1",
+            "redemptionType=type",
+        ].join("&");
+
+        expect(SaleToAcquirerDataParser.fromKeyValuePairs(raw)).toEqual({
+            shopperEmail: "foo@bar.com",
+            shopperReference: "ref-1",
+            shopperStatement: "statement",
+            recurringContract: "RECURRING",
+            recurringDetailName: "detail",
+            recurringTokenService: "service",
+            recurringProcessingModel: RecurringProcessingModel.Subscription,
+            store: "store-1",
+            merchantAccount: "TestMerchant",
+            currency: "USD",
+            tenderOption: "AskGratuity",
+            authorisationType: "PreAuth",
+            ssc: "1",
+            redemptionType: "type",
+        });
+    });
+
+    it("fromKeyValuePairs should handle metadata dotted notation", () => {
+        const raw = "shopperEmail=foo@bar.com&metadata.orderId=42&metadata.channel=pos";
+        expect(SaleToAcquirerDataParser.fromKeyValuePairs(raw)).toEqual({
+            shopperEmail: "foo@bar.com",
+            metadata: { orderId: "42", channel: "pos" },
+        });
+    });
+
+    it("fromKeyValuePairs should place unknown keys into additionalData", () => {
+        const raw = "shopperEmail=foo@bar.com&customField=customValue&another=value2";
+        expect(SaleToAcquirerDataParser.fromKeyValuePairs(raw)).toEqual({
+            shopperEmail: "foo@bar.com",
+            additionalData: { customField: "customValue", another: "value2" },
+        });
+    });
+
+    it("fromKeyValuePairs should drop unsupported recurringProcessingModel values", () => {
+        const result = SaleToAcquirerDataParser.fromKeyValuePairs("recurringProcessingModel=Unknown");
+        expect(result.recurringProcessingModel).toBeUndefined();
+    });
+
+    it("toJson and toBase64 should round-trip", () => {
+        const json = SaleToAcquirerDataParser.toJson(sample);
+        expect(JSON.parse(json)).toEqual(sample);
+
+        const base64 = SaleToAcquirerDataParser.toBase64(sample);
+        expect(SaleToAcquirerDataParser.parse(base64)).toEqual(sample);
+    });
+});
+
+describe("tapi SaleDataHelper", () => {
+    it("should return parsed data from Base64-encoded JSON", () => {
+        const acquirerData: SaleToAcquirerData = { shopperEmail: "foo@bar.com", currency: "EUR" };
+        const saleData = new SaleData();
+        saleData.SaleToAcquirerData = SaleToAcquirerDataParser.toBase64(acquirerData);
+
+        expect(new SaleDataHelper(saleData).getSaleToAcquirerData()).toEqual(acquirerData);
+    });
+
+    it("should return parsed data from key-value pairs", () => {
+        const saleData = new SaleData();
+        saleData.SaleToAcquirerData = "shopperEmail=foo@bar.com&currency=EUR";
+
+        expect(new SaleDataHelper(saleData).getSaleToAcquirerData()).toEqual({
+            shopperEmail: "foo@bar.com",
+            currency: "EUR",
+        });
+    });
+
+    it("should return null when SaleToAcquirerData is absent or empty", () => {
+        const empty = new SaleData();
+        expect(new SaleDataHelper(empty).getSaleToAcquirerData()).toBeNull();
+
+        const blank = new SaleData();
+        blank.SaleToAcquirerData = "   ";
+        expect(new SaleDataHelper(blank).getSaleToAcquirerData()).toBeNull();
+    });
+
+    it("should throw when constructed without SaleData", () => {
+        expect(() => new SaleDataHelper(undefined as unknown as SaleData)).toThrow();
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ export * from "./webhooks";
 // Export a utility function for HMAC validation
 export { hmacValidator } from "./utils";
 
+// Export TAPI (Cloud device API) helpers
+export { PredefinedContentHelper, DisplayNotificationEvent, SaleDataHelper, SaleToAcquirerData, RecurringProcessingModel, SaleToAcquirerDataParser } from "./utils/tapi";
+
 // Export the HTTP client implementation
 export { default as HttpURLConnectionClient } from "./httpClient/httpURLConnectionClient";
 

--- a/src/typings/tapi/models.ts
+++ b/src/typings/tapi/models.ts
@@ -156,6 +156,3 @@ export * from "./uTMCoordinates"
 
 // serializing and deserializing typed objects 
 export * from "./objectSerializer"
-
-// helpers
-export * from "../../utils/tapi/predefinedContentHelper"

--- a/src/utils/tapi/index.ts
+++ b/src/utils/tapi/index.ts
@@ -1,0 +1,23 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ * Adyen NodeJS API Library
+ * Copyright (c) 2026 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+export { PredefinedContentHelper, DisplayNotificationEvent } from "./predefinedContentHelper";
+export { SaleToAcquirerData, RecurringProcessingModel } from "./saleToAcquirerData";
+export { SaleDataHelper } from "./saleDataHelper";
+export * as SaleToAcquirerDataParser from "./saleToAcquirerDataParser";

--- a/src/utils/tapi/saleDataHelper.ts
+++ b/src/utils/tapi/saleDataHelper.ts
@@ -1,0 +1,67 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ * Adyen NodeJS API Library
+ * Copyright (c) 2026 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+import { SaleData } from "../../typings/tapi/saleData";
+import { SaleToAcquirerData } from "./saleToAcquirerData";
+import { parse } from "./saleToAcquirerDataParser";
+
+/**
+ * A helper class to work with `SaleData` from the TAPI (Cloud device API) model.
+ *
+ * The `SaleToAcquirerData` field supports two formats:
+ * - Base64-encoded JSON: a JSON object encoded as a Base64 string.
+ * - Key-value pairs: form-encoded pairs using `&` as separator
+ *   (e.g. `shopperEmail=foo@bar.com&tenderOption=AskGratuity`).
+ *
+ * This helper auto-detects the format and parses it into a {@link SaleToAcquirerData} object.
+ */
+export class SaleDataHelper {
+    private saleData: SaleData;
+
+    /**
+     * Constructs a helper instance wrapping the provided {@link SaleData}.
+     *
+     * @param saleData The {@link SaleData} instance to wrap.
+     */
+    constructor(saleData: SaleData) {
+        if (!saleData) {
+            throw new Error("saleData must not be null");
+        }
+        this.saleData = saleData;
+    }
+
+    /**
+     * Parses the `SaleToAcquirerData` field into a {@link SaleToAcquirerData} object.
+     * Supports both Base64-encoded JSON and form-encoded key-value pair formats.
+     *
+     * @returns The parsed {@link SaleToAcquirerData}, or `null` if the field is absent
+     * or cannot be parsed.
+     */
+    getSaleToAcquirerData(): SaleToAcquirerData | null {
+        const raw = this.saleData.SaleToAcquirerData;
+        if (!raw || raw.trim() === "") {
+            return null;
+        }
+        try {
+            return parse(raw);
+        } catch {
+            return null;
+        }
+    }
+}

--- a/src/utils/tapi/saleToAcquirerData.ts
+++ b/src/utils/tapi/saleToAcquirerData.ts
@@ -1,0 +1,55 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ * Adyen NodeJS API Library
+ * Copyright (c) 2026 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+/**
+ * Recurring processing model as expected in the `SaleToAcquirerData` field.
+ */
+export enum RecurringProcessingModel {
+    Subscription = "Subscription",
+    CardOnFile = "CardOnFile",
+    UnscheduledCardOnFile = "UnscheduledCardOnFile",
+}
+
+/**
+ * Sale information intended for the Acquirer, decoded from the `SaleData.SaleToAcquirerData` field.
+ *
+ * The field supports two wire formats:
+ * - Base64-encoded JSON: a JSON object encoded as a Base64 string.
+ * - Key-value pairs: form-encoded pairs using `&` as separator
+ *   (e.g. `shopperEmail=foo@bar.com&tenderOption=AskGratuity`).
+ */
+export interface SaleToAcquirerData {
+    metadata?: Record<string, string>;
+    shopperEmail?: string;
+    shopperReference?: string;
+    recurringContract?: string;
+    shopperStatement?: string;
+    recurringDetailName?: string;
+    recurringTokenService?: string;
+    store?: string;
+    merchantAccount?: string;
+    currency?: string;
+    applicationInfo?: Record<string, unknown>;
+    tenderOption?: string;
+    additionalData?: Record<string, string>;
+    authorisationType?: string;
+    ssc?: string;
+    recurringProcessingModel?: RecurringProcessingModel;
+    redemptionType?: string;
+}

--- a/src/utils/tapi/saleToAcquirerDataParser.ts
+++ b/src/utils/tapi/saleToAcquirerDataParser.ts
@@ -77,8 +77,14 @@ export function fromKeyValuePairs(keyValuePairs: string): SaleToAcquirerData {
 
     const params = new URLSearchParams(keyValuePairs);
     for (const [key, value] of params) {
+        if (!key) {
+            continue;
+        }
         if (key.startsWith("metadata.")) {
-            metadata[key.substring("metadata.".length)] = value;
+            const subKey = key.substring("metadata.".length);
+            if (subKey) {
+                metadata[subKey] = value;
+            }
             continue;
         }
         switch (key) {
@@ -167,11 +173,8 @@ export function toBase64(data: SaleToAcquirerData): string {
  */
 function tryDecodeBase64Json(raw: string): SaleToAcquirerData | null {
     try {
-        const decoded = Buffer.from(raw, "base64").toString("utf8");
-        // Reject inputs that are not round-trip safe Base64 (e.g. plain key-value strings).
-        if (Buffer.from(decoded, "utf8").toString("base64").replace(/=+$/, "") !== raw.replace(/=+$/, "")) {
-            return null;
-        }
+        const sanitized = raw.replace(/\s/g, "");
+        const decoded = Buffer.from(sanitized, "base64").toString("utf8");
         if (decoded.trim().startsWith("{")) {
             return JSON.parse(decoded) as SaleToAcquirerData;
         }

--- a/src/utils/tapi/saleToAcquirerDataParser.ts
+++ b/src/utils/tapi/saleToAcquirerDataParser.ts
@@ -1,0 +1,182 @@
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ * Adyen NodeJS API Library
+ * Copyright (c) 2026 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
+
+import { RecurringProcessingModel, SaleToAcquirerData } from "./saleToAcquirerData";
+
+const RECURRING_PROCESSING_MODELS = Object.values(RecurringProcessingModel) as string[];
+
+/**
+ * Parses and serializes {@link SaleToAcquirerData} objects from/to their wire formats.
+ *
+ * Supports two formats:
+ * - Base64-encoded JSON: a JSON object encoded as a Base64 string.
+ * - Key-value pairs: form-encoded pairs using `&` as separator
+ *   (e.g. `shopperEmail=foo@bar.com&tenderOption=AskGratuity`).
+ */
+
+/**
+ * Parses a raw `SaleToAcquirerData` string, auto-detecting the format.
+ *
+ * - If the string is valid Base64 and decodes to a JSON object, it is parsed as JSON.
+ * - Otherwise it is parsed as form-encoded key-value pairs.
+ *
+ * @param raw The raw `SaleToAcquirerData` string.
+ * @returns Parsed {@link SaleToAcquirerData}.
+ */
+export function parse(raw: string): SaleToAcquirerData {
+    const decoded = tryDecodeBase64Json(raw);
+    if (decoded !== null) {
+        return decoded;
+    }
+    return fromKeyValuePairs(raw);
+}
+
+/**
+ * Decodes a Base64-encoded JSON string into a {@link SaleToAcquirerData} object.
+ *
+ * @param base64 Base64-encoded JSON string.
+ * @returns Decoded {@link SaleToAcquirerData}.
+ */
+export function fromBase64(base64: string): SaleToAcquirerData {
+    try {
+        const json = Buffer.from(base64, "base64").toString("utf8");
+        return JSON.parse(json) as SaleToAcquirerData;
+    } catch (e) {
+        throw new Error(`Failed to deserialize SaleToAcquirerData: ${(e as Error).message}`);
+    }
+}
+
+/**
+ * Parses a form-encoded key-value pair string (e.g.
+ * `shopperEmail=foo@bar.com&tenderOption=AskGratuity`) into a {@link SaleToAcquirerData} object.
+ * Metadata fields use dotted notation: `metadata.key=value`.
+ *
+ * @param keyValuePairs Form-encoded key-value string using `&` as separator.
+ * @returns Parsed {@link SaleToAcquirerData}.
+ */
+export function fromKeyValuePairs(keyValuePairs: string): SaleToAcquirerData {
+    const data: SaleToAcquirerData = {};
+    const metadata: Record<string, string> = {};
+    const additionalData: Record<string, string> = {};
+
+    const params = new URLSearchParams(keyValuePairs);
+    for (const [key, value] of params) {
+        if (key.startsWith("metadata.")) {
+            metadata[key.substring("metadata.".length)] = value;
+            continue;
+        }
+        switch (key) {
+            case "shopperEmail":
+                data.shopperEmail = value;
+                break;
+            case "shopperReference":
+                data.shopperReference = value;
+                break;
+            case "shopperStatement":
+                data.shopperStatement = value;
+                break;
+            case "recurringContract":
+                data.recurringContract = value;
+                break;
+            case "recurringDetailName":
+                data.recurringDetailName = value;
+                break;
+            case "recurringTokenService":
+                data.recurringTokenService = value;
+                break;
+            case "recurringProcessingModel":
+                data.recurringProcessingModel = RECURRING_PROCESSING_MODELS.includes(value)
+                    ? (value as RecurringProcessingModel)
+                    : undefined;
+                break;
+            case "store":
+                data.store = value;
+                break;
+            case "merchantAccount":
+                data.merchantAccount = value;
+                break;
+            case "currency":
+                data.currency = value;
+                break;
+            case "tenderOption":
+                data.tenderOption = value;
+                break;
+            case "authorisationType":
+                data.authorisationType = value;
+                break;
+            case "ssc":
+                data.ssc = value;
+                break;
+            case "redemptionType":
+                data.redemptionType = value;
+                break;
+            default:
+                additionalData[key] = value;
+                break;
+        }
+    }
+
+    if (Object.keys(metadata).length > 0) {
+        data.metadata = metadata;
+    }
+    if (Object.keys(additionalData).length > 0) {
+        data.additionalData = additionalData;
+    }
+    return data;
+}
+
+/**
+ * Serializes a {@link SaleToAcquirerData} object to a JSON string.
+ *
+ * @param data The object to serialize.
+ * @returns JSON string representation.
+ */
+export function toJson(data: SaleToAcquirerData): string {
+    return JSON.stringify(data);
+}
+
+/**
+ * Encodes a {@link SaleToAcquirerData} object to a Base64-encoded JSON string.
+ *
+ * @param data The object to encode.
+ * @returns Base64-encoded JSON representation.
+ */
+export function toBase64(data: SaleToAcquirerData): string {
+    return Buffer.from(toJson(data), "utf8").toString("base64");
+}
+
+/**
+ * Attempts to decode a Base64-encoded JSON object. Returns null when the input is not
+ * valid Base64 or does not decode to a JSON object.
+ */
+function tryDecodeBase64Json(raw: string): SaleToAcquirerData | null {
+    try {
+        const decoded = Buffer.from(raw, "base64").toString("utf8");
+        // Reject inputs that are not round-trip safe Base64 (e.g. plain key-value strings).
+        if (Buffer.from(decoded, "utf8").toString("base64").replace(/=+$/, "") !== raw.replace(/=+$/, "")) {
+            return null;
+        }
+        if (decoded.trim().startsWith("{")) {
+            return JSON.parse(decoded) as SaleToAcquirerData;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
**Description**

Adds TAPI (Cloud device API) helpers to parse and serialize the `SaleData.SaleToAcquirerData` field, which is a "stringly-typed" field carrying acquirer data in one of two wire formats (Base64-encoded JSON or form-encoded key-value pairs). This aligns the Node library with the Java library.

New in `src/utils/tapi/`:
- `SaleToAcquirerData` interface + `RecurringProcessingModel` enum (typed model of the decoded payload).
- `SaleToAcquirerDataParser` namespace: `parse` (auto-detects the format), `fromBase64`, `fromKeyValuePairs` (supports `metadata.*` dotted notation; unknown keys go to `additionalData`), `toJson`, `toBase64`.
- `SaleDataHelper`: wraps a `SaleData` and exposes `getSaleToAcquirerData()`, returning the parsed object or `null` when absent/unparsable.

The utils exports have been improved to expose all TAPI helpers in a single (public) way that simplifies the integration experience.
Example usage:
```ts
import { PredefinedContentHelper, DisplayNotificationEvent, SaleDataHelper, SaleToAcquirerData, RecurringProcessingModel, SaleToAcquirerDataParser } from "@adyen/api-library";
```

Updated `doc/CloudDeviceApi.md` Helper classes section with usage snippets for all three helpers.

Add relevant tests.

