### PR TITLE
Fix SaleToAcquirerData additionalData value types

### DIFF
--- a/doc/CloudDeviceApi.md
+++ b/doc/CloudDeviceApi.md
@@ -219,6 +219,8 @@ console.log(acquirerData);
 
 Use `SaleToAcquirerDataParser` directly when you have the raw string, or when you want to build and encode a `SaleToAcquirerData` payload yourself. It exposes `parse` (auto-detects the format), the explicit `fromBase64` / `fromKeyValuePairs` decoders, and the `toJson` / `toBase64` serializers.
 
+Values in `additionalData` can be strings, numbers, or booleans. Use the type required by the API for each field. For example, `captureDelayHours` must be a number.
+
 ``` typescript
 import { SaleToAcquirerDataParser, SaleToAcquirerData, RecurringProcessingModel } from "@adyen/api-library";
 
@@ -232,6 +234,10 @@ const data: SaleToAcquirerData = {
     shopperReference: "shopper-123",
     recurringProcessingModel: RecurringProcessingModel.CardOnFile,
     metadata: { orderId: "42" },
+    additionalData: {
+        manualCapture: "true",
+        captureDelayHours: 192,
+    },
 };
 
 const encoded = SaleToAcquirerDataParser.toBase64(data); // Base64 string, ready to assign to SaleData.SaleToAcquirerData

--- a/src/__tests__/cloudDevice/cloudDeviceApi.terminal.spec.ts
+++ b/src/__tests__/cloudDevice/cloudDeviceApi.terminal.spec.ts
@@ -37,6 +37,7 @@ import {
 } from "../../typings/tapi/models";
 import { EncryptedCloudDeviceApi } from "../../services/clouddevice/encryptedCloudDeviceApi";
 import { EncryptionCredentialDetails } from "../../security/clouddevice/encryptionCredentialDetails";
+import { SaleToAcquirerDataParser } from "../../utils/tapi";
 
 /*
 Verify Terminal integration: tests to send API requests to the Cloud Device API and confirm the Terminal responds as expected.
@@ -229,6 +230,12 @@ const hasEncryptedEnv = !!(hasEnv && ADYEN_TERMINAL_DEVICE_KEY_IDENTIFIER && ADY
                 TransactionID: id,
                 TimeStamp: new Date(),
             },
+            SaleToAcquirerData: SaleToAcquirerDataParser.toBase64({
+                additionalData: {
+                    manualCapture: "true",
+                    captureDelayHours: 1,
+                },
+            }),
         };
 
         const saleToPOIRequest: SaleToPOIRequest = new SaleToPOIRequest();

--- a/src/__tests__/utils/tapi/saleToAcquirerData.spec.ts
+++ b/src/__tests__/utils/tapi/saleToAcquirerData.spec.ts
@@ -117,6 +117,20 @@ describe("tapi SaleToAcquirerDataParser", () => {
         const base64 = SaleToAcquirerDataParser.toBase64(sample);
         expect(SaleToAcquirerDataParser.parse(base64)).toEqual(sample);
     });
+
+    it("toBase64 should preserve additionalData value types", () => {
+        const data: SaleToAcquirerData = {
+            additionalData: {
+                manualCapture: "true",
+                captureDelayHours: 192,
+                "taxfree.indicator": false,
+            },
+        };
+
+        const base64 = SaleToAcquirerDataParser.toBase64(data);
+
+        expect(SaleToAcquirerDataParser.fromBase64(base64)).toEqual(data);
+    });
 });
 
 describe("tapi SaleDataHelper", () => {

--- a/src/utils/tapi/saleToAcquirerData.ts
+++ b/src/utils/tapi/saleToAcquirerData.ts
@@ -47,7 +47,7 @@ export interface SaleToAcquirerData {
     currency?: string;
     applicationInfo?: Record<string, unknown>;
     tenderOption?: string;
-    additionalData?: Record<string, string>;
+    additionalData?: Record<string, string | number | boolean>;
     authorisationType?: string;
     ssc?: string;
     recurringProcessingModel?: RecurringProcessingModel;


### PR DESCRIPTION
**Description**
Widen `SaleToAcquirerData.additionalData` values to support strings, numbers, and booleans. This allows fields such as `captureDelayHours` to retain their required numeric JSON representation when encoded as Base64.

Add regression coverage, a terminal integration example, and Cloud Device API documentation for numeric capture delays.

**Tested scenarios**
- `npm test -- --runInBand src/__tests__/utils/tapi/saleToAcquirerData.spec.ts src/__tests__/cloudDevice/cloudDeviceApi.terminal.spec.ts`
- `npm run build`
- `npm run lint`
- Confirmed with a test terminal that numeric `captureDelayHours` leaves the payment authorised and unsettled.

**Note**
This is not a breaking change because it only broadens the accepted `additionalData` value types. Existing string values remain fully supported, while numbers and booleans are now also accepted.

**Fixed issue**: #1739
