### PR TITLE
docs: fix Banking webhook HMAC example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,10 @@ if ("accountHolderCode" in genericWebhook) {
 ```
 Verify the authenticity (where you retrieve the hmac key from the CA and the signature from the webhook header);
 ``` typescript
-const isValid = hmacValidator.validateHMACSignature("YOUR_HMAC_KEY", "YOUR_HMAC_SIGNATURE", jsonString)
+import { hmacValidator } from "@adyen/api-library";
+
+const validator = new hmacValidator();
+const isValid = validator.validateHMACSignature("YOUR_HMAC_KEY", "YOUR_HMAC_SIGNATURE", jsonString);
 ```
 ### Management Webhooks
 Management webhooks are also parsed with the same approach, using `ManagementWebhooksHandler`:

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ if ("accountHolderCode" in genericWebhook) {
 ```
 Verify the authenticity (where you retrieve the hmac key from the CA and the signature from the webhook header);
 ``` typescript
-const isValid = hmacValidator.validateBankingHMAC("YOUR_HMAC_KEY", "YOUR_HMAC_SIGNATURE", jsonString)
+const isValid = hmacValidator.validateHMACSignature("YOUR_HMAC_KEY", "YOUR_HMAC_SIGNATURE", jsonString)
 ```
 ### Management Webhooks
 Management webhooks are also parsed with the same approach, using `ManagementWebhooksHandler`:


### PR DESCRIPTION
## Summary

I hit this while building against the Adyen Node.js API library. The "Parsing and Authenticating Banking Webhooks" example in the README never worked. `isValid` came back `false` every time.

## Root cause

The example calls the deprecated `validateBankingHMAC` method:

```js
hmacValidator.validateBankingHMAC("YOUR_HMAC_KEY", "YOUR_HMAC_SIGNATURE", jsonString)
```

The implementation reads those arguments the other way around. It signs with the first one and compares against the second:

```ts
const expectedSign = createHmac(..., Buffer.from(hmacSign, "hex")).update(notification).digest("base64");
return HmacValidator.secureCompare(expectedSign, hmacKey);
```

Pass `(KEY, SIGNATURE)` in the order the names suggest and you get `false` forever. The example is a trap, and a silent one at that.

## Fix

Point the example at the non-deprecated `validateHMACSignature(hmacKey, hmacSignature, data)`, which takes its arguments in the order the names suggest:

```js
const isValid = hmacValidator.validateHMACSignature("YOUR_HMAC_KEY", "YOUR_HMAC_SIGNATURE", jsonString)
```

I checked the implementation in `src/utils/hmacValidator.ts` and the tests in `src/__tests__/hmacValidator.spec.ts` before writing this. The change is one line, and it makes the example do what it claims.
