### PR TITLE
Update fast-uri to 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3133,9 +3133,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
**Description**
Updates the transitive `fast-uri` dependency from 3.1.2 to 3.1.5 in `package-lock.json`, resolving all three related Dependabot alerts.

**Tested scenarios**
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand` (one transient timeout in `capital.spec.ts`; the targeted rerun passed)
- `npm test -- --runInBand src/__tests__/capital.spec.ts`
- `npm audit --json` confirms `fast-uri` is no longer reported; unrelated existing advisories remain

**Fixed issues**:
- [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx)
- [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7)
- [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6)
