### PR TITLE
Update ajv to 6.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,9 +1908,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
**Description**
Updates the transitive `ajv` 6.x dependency from 6.12.6 to 6.15.0 in `package-lock.json`, resolving the related Dependabot alert.

**Tested scenarios**
- `npm ci`
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand`
- `npm audit --json` confirms the vulnerable `ajv` 6.x package is no longer reported; unrelated existing advisories remain

**Fixed issue**:
- [GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6)
