### PR TITLE
Override micromatch to 4.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5845,20 +5845,6 @@
         "typescript": "^4.X.X"
       }
     },
-    "node_modules/ts-auto-mock/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/ts-jest": {
       "version": "29.4.11",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "overrides": {
     "lodash": "^4.18.0",
     "lodash-es": "^4.18.0",
+    "micromatch": "^4.0.8",
     "picomatch": "^2.3.2",
     "ts-auto-mock": "~3.6.0"
   }


### PR DESCRIPTION
**Description**
Adds an npm override for `micromatch` 4.0.8, replacing the vulnerable 4.0.5 copy pinned by `ts-auto-mock` 3.6.4.

The latest `ts-auto-mock` requires TypeScript 5, while this project uses TypeScript 4.9.5. The override resolves the advisory without introducing an unrelated TypeScript migration. npm deduplicates all `micromatch` consumers onto 4.0.8.

**Tested scenarios**
- `npm ci`
- `npm ls micromatch ts-auto-mock --all`
- `npm run build`
- `npm run lint`
- `npm test -- --runInBand`
- `npm audit --json` confirms both `micromatch` and the derived `ts-auto-mock` finding are no longer reported; unrelated existing advisories remain

**Fixed issue**:
- [GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv)
