### PR TITLE
Export Session Authentication types

### DIFF
--- a/src/__tests__/sessionAuthenticationApi.spec.ts
+++ b/src/__tests__/sessionAuthenticationApi.spec.ts
@@ -1,4 +1,5 @@
 import nock from "nock";
+import { Types } from "../index";
 import { createClient } from "../__mocks__/base";
 import SessionAuthenticationApi from "../services/sessionAuthentication";
 import Client from "../client";
@@ -7,6 +8,15 @@ import { AccountHolderResource, AuthenticationSessionRequest, AuthenticationSess
 let client: Client;
 let sessionAuthenticationApi: SessionAuthenticationApi;
 let scope: nock.Scope;
+
+describe("Session Authentication public types", (): void => {
+    test("exports AuthenticationSessionRequest through Types", (): void => {
+        const request: Types.sessionAuthentication.AuthenticationSessionRequest =
+            new Types.sessionAuthentication.AuthenticationSessionRequest();
+
+        expect(request).toBeInstanceOf(Types.sessionAuthentication.AuthenticationSessionRequest);
+    });
+});
 
 beforeEach((): void => {
     if (!nock.isActive()) {

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -24,6 +24,7 @@ export * as platformsAccount from "./platformsAccount/models";
 export * as platformsFund from "./platformsFund/models";
 export * as platformsHostedOnboardingPage from "./platformsHostedOnboardingPage/models";
 export * as recurring from "./recurring/models";
+export * as sessionAuthentication from "./sessionAuthentication/models";
 export * as storedValue from "./storedValue/models";
 export * as tapi from "./tapi/models";
 export * as terminal from "./terminal/models";


### PR DESCRIPTION
## Problem

`SessionAuthenticationAPI` is publicly available, but its generated request and response models are not exposed through the public `Types` namespace.

## Fix

Add the missing manually maintained `sessionAuthentication` namespace export in `src/typings/index.ts` and cover it through the public package entrypoint.

## Tests

- `npm run build`
- `npm test -- --runInBand src/__tests__/sessionAuthenticationApi.spec.ts` (4 passed)
- `npm run lint`
- `npm test -- --runInBand` (53 suites and 620 tests passed; the five existing `capital.spec.ts` failures reproduce on pristine main at the base SHA)
- `git diff --check`

## Issue

Fixes #1751

## AI assistance

AI assistance was used during investigation and verification. Shin reviewed the final change, tests, and scope and owns the submission.