### PR TITLE
[Bug]: Remove redundant void statements from generated APIs

### DIFF
--- a/templates-v7/typescript/api/api.mustache
+++ b/templates-v7/typescript/api/api.mustache
@@ -9,9 +9,6 @@ import { ObjectSerializer } from "../../typings/{{serviceName}}/objectSerializer
 {{#imports}}
 import { {{classname}} } from "../../typings/{{serviceName}}/models";
 {{/imports}}
-{{#imports}}
-void {{classname}};
-{{/imports}}
 {{#operations}}
 
 /**


### PR DESCRIPTION
**Description**
PR to remove the API template loop that emitted `void` statements for every imported model. 
This is a regression caused by #1761.

The SDK automation formatting step already removes unused generated imports before creating pull requests, so these statements are unnecessary and prevent that cleanup.

Existing generated API files are unchanged and will lose the statements when their services are regenerated.

**Tested scenarios**
- Regenerated BinLookup through `adyen-sdk-automation`
- Ran the same `npm run lint:fix` formatting step used by SDK automation and confirmed the unused `ServiceError` import was removed
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` (638 passed, 27 skipped)

**Fixed issue**:
